### PR TITLE
[Feat] Implement team leave functionality and refactor notification system

### DIFF
--- a/src/main/java/dev/tecte/chessWar/board/application/BoardNotifier.java
+++ b/src/main/java/dev/tecte/chessWar/board/application/BoardNotifier.java
@@ -1,0 +1,28 @@
+package dev.tecte.chessWar.board.application;
+
+import dev.tecte.chessWar.port.notifier.SenderNotifier;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+
+/**
+ * 체스판 관련 알림 및 안내 메시지를 전송합니다.
+ */
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class BoardNotifier {
+    private final SenderNotifier senderNotifier;
+
+    /**
+     * 체스판 생성 성공을 알립니다.
+     *
+     * @param recipient 알림을 받을 대상
+     */
+    public void notifyBoardCreate(@NonNull CommandSender recipient) {
+        senderNotifier.notifySuccess(recipient, Component.text("체스판이 생성되었습니다.", NamedTextColor.WHITE));
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/board/application/BoardService.java
+++ b/src/main/java/dev/tecte/chessWar/board/application/BoardService.java
@@ -9,14 +9,11 @@ import dev.tecte.chessWar.board.domain.model.spec.BorderSpec;
 import dev.tecte.chessWar.board.domain.model.spec.GridSpec;
 import dev.tecte.chessWar.board.domain.model.spec.SquareSpec;
 import dev.tecte.chessWar.board.domain.service.BoardFactory;
-import dev.tecte.chessWar.port.notifier.SenderNotifier;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
@@ -24,27 +21,22 @@ import org.bukkit.util.Vector;
 import java.util.Optional;
 
 /**
- * 체스판 도메인 로직을 수행하는 서비스입니다.
+ * 체스판 관련 비즈니스 로직을 처리합니다.
  */
 @Slf4j(topic = "ChessWar")
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class BoardService {
-    private static final Component BOARD_CREATE_SUCCESS = Component.text(
-            "체스판이 생성되었습니다.",
-            NamedTextColor.WHITE
-    );
-
     private final BoardFactory boardFactory;
+    private final BoardNotifier boardNotifier;
     private final BoardRenderer boardRenderer;
     private final BoardRepository boardRepository;
     private final GridSpec gridSpec;
     private final SquareSpec squareSpec;
     private final BorderSpec borderSpec;
-    private final SenderNotifier senderNotifier;
 
     /**
-     * 플레이어의 위치와 방향을 기준으로 새로운 체스판을 생성합니다.
+     * 플레이어의 위치와 방향을 기준으로 체스판을 생성합니다.
      *
      * @param player 체스판을 생성할 플레이어
      */
@@ -66,13 +58,13 @@ public class BoardService {
 
         boardRenderer.render(board, world);
         boardRepository.save(board);
-        senderNotifier.notifySuccess(player, BOARD_CREATE_SUCCESS);
+        boardNotifier.notifyBoardCreate(player);
         log.info("Player '{}' created a new chessboard at {} in world '{}'",
                 player.getName(), playerPosition, world.getName());
     }
 
     /**
-     * 저장된 체스판을 찾습니다.
+     * 체스판을 찾습니다.
      *
      * @return 찾은 체스판
      */

--- a/src/main/java/dev/tecte/chessWar/board/infrastructure/command/BoardCommand.java
+++ b/src/main/java/dev/tecte/chessWar/board/infrastructure/command/BoardCommand.java
@@ -24,7 +24,7 @@ public class BoardCommand extends BaseCommand {
     private final BoardService boardService;
 
     /**
-     * 새로운 체스판을 생성합니다.
+     * 체스판을 생성합니다.
      *
      * @param player 명령어를 실행한 플레이어
      */

--- a/src/main/java/dev/tecte/chessWar/board/infrastructure/persistence/YmlBoardRepository.java
+++ b/src/main/java/dev/tecte/chessWar/board/infrastructure/persistence/YmlBoardRepository.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 /**
- * YML 파일을 사용하여 단일 체스판의 영속성을 관리하는 BoardRepository 구현체입니다.
+ * YML 파일을 사용하여 체스판의 영속성을 관리합니다.
  */
 @Singleton
 public class YmlBoardRepository extends AbstractSingleYmlRepository<Board> implements BoardRepository {

--- a/src/main/java/dev/tecte/chessWar/game/application/GameNotifier.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/GameNotifier.java
@@ -21,17 +21,8 @@ import java.util.Set;
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class GameNotifier {
-    private static final Component PIECE_SELECTION_TITLE =
-            Component.text("기물 선택").decorate(TextDecoration.BOLD).color(NamedTextColor.AQUA);
-    private static final Component PIECE_SELECTION_GUIDE =
-            Component.text("기물을 우클릭하여 참전할 기물을 선택해주세요.").color(NamedTextColor.RED);
-    private static final Component GAME_STOP_MESSAGE = Component.text("게임이 중단되었습니다.");
-
-    private static final long GUIDE_INITIAL_DELAY_TICKS = 0L;
-    private static final long GUIDE_INTERVAL_TICKS = 40L;
-
-    private final GameTaskScheduler gameTaskScheduler;
     private final TeamService teamService;
+    private final GameTaskScheduler gameTaskScheduler;
     private final SenderNotifier senderNotifier;
 
     /**
@@ -40,18 +31,27 @@ public class GameNotifier {
      * @param recipients 알림을 받을 대상
      */
     public void announcePieceSelectionStart(@NonNull Set<Player> recipients) {
-        recipients.forEach(player -> senderNotifier.sendTitle(player, PIECE_SELECTION_TITLE));
+        Component title = Component.text("기물 선택")
+                .decorate(TextDecoration.BOLD)
+                .color(NamedTextColor.AQUA);
+
+        recipients.forEach(player -> senderNotifier.sendTitle(player, title));
     }
 
     /**
      * 기물 선택 가이드 안내를 시작합니다.
      */
     public void startPieceSelectionGuidance() {
+        Component guideMessage = Component.text("기물을 우클릭하여 참전할 기물을 선택해주세요.")
+                .color(NamedTextColor.RED);
+        long initialDelay = 0L;
+        long intervalTicks = 2 * 20L;
+
         gameTaskScheduler.scheduleRepeat(
                 GameTaskType.GUIDANCE,
-                () -> broadcastActionBar(PIECE_SELECTION_GUIDE),
-                GUIDE_INITIAL_DELAY_TICKS,
-                GUIDE_INTERVAL_TICKS
+                () -> broadcastActionBar(guideMessage),
+                initialDelay,
+                intervalTicks
         );
     }
 
@@ -69,7 +69,7 @@ public class GameNotifier {
      * @param recipient 알림을 받을 대상
      */
     public void notifyGameStop(@NonNull CommandSender recipient) {
-        senderNotifier.notifySuccess(recipient, GAME_STOP_MESSAGE);
+        senderNotifier.notifySuccess(recipient, "게임이 중단되었습니다.");
     }
 
     private void broadcastActionBar(Component message) {

--- a/src/main/java/dev/tecte/chessWar/game/application/PieceSelectionService.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/PieceSelectionService.java
@@ -26,7 +26,7 @@ import org.bukkit.entity.Player;
 import java.util.UUID;
 
 /**
- * 기물 선택 및 참전 로직을 처리하는 서비스입니다.
+ * 기물 선택 및 참전 로직을 처리합니다.
  */
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
@@ -36,20 +36,12 @@ public class PieceSelectionService {
     private final SenderNotifier senderNotifier;
 
     /**
-     * 플레이어가 선택한 기물로 참전합니다.
-     * <p>
-     * 참전 시 해당 기물의 스펙에 맞춰 플레이어의 능력치가 조정되며, 체력이 최대치로 회복됩니다.
-     * <p>
-     * <b>참전 제약 사항:</b>
-     * <ul>
-     *   <li>선택 불가능한 기물은 선택할 수 없습니다.</li>
-     *   <li>이미 다른 플레이어가 참전 중인 기물은 선택할 수 없습니다.</li>
-     * </ul>
+     * 기물을 선택하여 참전합니다.
      *
      * @param player  참전할 플레이어
-     * @param pieceId 선택할 기물의 식별자
+     * @param pieceId 선택할 기물의 ID
      * @throws GameException  진행 중인 게임이 없거나 게임에 포함되지 않은 기물일 경우
-     * @throws PieceException 참전 제약 사항을 위반한 경우
+     * @throws PieceException 기물이 선택 불가능하거나 이미 선택된 경우
      */
     @HandleException
     public void selectPiece(@NonNull Player player, @NonNull UUID pieceId) {

--- a/src/main/java/dev/tecte/chessWar/infrastructure/notifier/BukkitSenderNotifier.java
+++ b/src/main/java/dev/tecte/chessWar/infrastructure/notifier/BukkitSenderNotifier.java
@@ -9,7 +9,7 @@ import net.kyori.adventure.title.Title;
 import org.bukkit.command.CommandSender;
 
 /**
- * 메시지를 전송합니다.
+ * Bukkit을 통해 알림 및 안내 메시지를 전송합니다.
  */
 @Singleton
 public class BukkitSenderNotifier implements SenderNotifier {

--- a/src/main/java/dev/tecte/chessWar/infrastructure/persistence/AbstractSingleYmlRepository.java
+++ b/src/main/java/dev/tecte/chessWar/infrastructure/persistence/AbstractSingleYmlRepository.java
@@ -17,11 +17,11 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 /**
- * 단일 엔티티 영속성을 관리하는 추상 리포지토리입니다.
+ * 단일 도메인 객체의 영속성을 관리합니다.
  * <p>
- * 인메모리 캐싱을 통해 접근 성능을 향상시키고, 비동기 저장을 통해 메인 스레드 부하를 줄입니다.
+ * 캐싱을 통해 접근 성능을 높이고, 비동기 저장으로 메인 스레드 부하를 방지합니다.
  *
- * @param <V> 관리하는 엔티티의 타입
+ * @param <V> 관리할 도메인 객체 타입
  */
 @Slf4j(topic = "ChessWar")
 @RequiredArgsConstructor(onConstructor_ = @Inject)
@@ -45,9 +45,9 @@ public abstract class AbstractSingleYmlRepository<V> implements PersistableState
     }
 
     /**
-     * 캐시된 엔티티를 반환합니다.
+     * 캐시된 도메인 객체를 찾습니다.
      *
-     * @return 찾은 엔티티
+     * @return 찾은 객체
      */
     @NonNull
     public Optional<V> find() {
@@ -55,9 +55,9 @@ public abstract class AbstractSingleYmlRepository<V> implements PersistableState
     }
 
     /**
-     * 엔티티를 저장하고 비동기적으로 반영합니다.
+     * 도메인 객체를 저장하고 비동기적으로 반영합니다.
      *
-     * @param entity 저장할 엔티티
+     * @param entity 저장할 객체
      */
     public void save(@NonNull V entity) {
         cache = entity;
@@ -65,7 +65,7 @@ public abstract class AbstractSingleYmlRepository<V> implements PersistableState
     }
 
     /**
-     * 현재 저장된 엔티티를 삭제합니다.
+     * 저장된 도메인 객체를 삭제합니다.
      */
     public void delete() {
         cache = null;
@@ -80,19 +80,19 @@ public abstract class AbstractSingleYmlRepository<V> implements PersistableState
     }
 
     /**
-     * 데이터 섹션에서 엔티티를 역직렬화합니다.
+     * 도메인 객체를 역직렬화합니다.
      *
      * @param section 데이터 섹션
-     * @return 역직렬화된 엔티티
+     * @return 역직렬화된 객체
      */
     @NonNull
     protected abstract V deserialize(@NonNull ConfigurationSection section);
 
     /**
-     * 엔티티를 데이터 맵으로 직렬화합니다.
+     * 도메인 객체를 직렬화합니다.
      *
-     * @param entity 직렬화할 엔티티
-     * @return 직렬화된 데이터 맵
+     * @param entity 직렬화할 객체
+     * @return 직렬화된 맵
      */
     @NonNull
     protected abstract Map<String, Object> serialize(@NonNull V entity);

--- a/src/main/java/dev/tecte/chessWar/piece/infrastructure/bootstrap/PieceModule.java
+++ b/src/main/java/dev/tecte/chessWar/piece/infrastructure/bootstrap/PieceModule.java
@@ -12,7 +12,7 @@ import dev.tecte.chessWar.piece.application.port.PieceSpawner;
 import dev.tecte.chessWar.piece.application.port.PieceStatProvider;
 import dev.tecte.chessWar.piece.domain.model.PieceLayout;
 import dev.tecte.chessWar.piece.infrastructure.bukkit.BukkitPieceInfoRenderer;
-import dev.tecte.chessWar.piece.infrastructure.command.PieceSelectCommand;
+import dev.tecte.chessWar.piece.infrastructure.command.PieceCommand;
 import dev.tecte.chessWar.piece.infrastructure.listener.PieceInteractionListener;
 import dev.tecte.chessWar.piece.infrastructure.mythicmobs.MythicMobsPieceIdResolver;
 import dev.tecte.chessWar.piece.infrastructure.mythicmobs.MythicMobsPieceLayoutLoader;
@@ -37,7 +37,7 @@ public class PieceModule extends AbstractModule {
         bind(PieceStatProvider.class).to(MythicMobsPieceStatProvider.class);
         bind(PieceIdResolver.class).to(MythicMobsPieceIdResolver.class);
 
-        Multibinder.newSetBinder(binder(), BaseCommand.class).addBinding().to(PieceSelectCommand.class);
+        Multibinder.newSetBinder(binder(), BaseCommand.class).addBinding().to(PieceCommand.class);
         Multibinder.newSetBinder(binder(), Listener.class).addBinding().to(PieceInteractionListener.class);
     }
 

--- a/src/main/java/dev/tecte/chessWar/piece/infrastructure/command/PieceCommand.java
+++ b/src/main/java/dev/tecte/chessWar/piece/infrastructure/command/PieceCommand.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 @Subcommand(PieceCommandConstants.PIECE)
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 @SuppressWarnings("unused")
-public class PieceSelectCommand extends BaseCommand {
+public class PieceCommand extends BaseCommand {
     private final PieceSelectionService pieceSelectionService;
     private final SenderNotifier senderNotifier;
 
@@ -31,7 +31,7 @@ public class PieceSelectCommand extends BaseCommand {
      * 플레이어가 대상 기물이 되어 전장에 참전합니다.
      *
      * @param player  명령어를 실행한 플레이어
-     * @param pieceId 참전할 대상 기물의 식별자
+     * @param pieceId 참전할 대상 기물의 ID
      */
     @Subcommand(PieceCommandConstants.SELECT)
     @Description("플레이어가 대상 기물이 되어 전장에 참전합니다.")

--- a/src/main/java/dev/tecte/chessWar/piece/infrastructure/mythicmobs/exception/MythicMobSpawnException.java
+++ b/src/main/java/dev/tecte/chessWar/piece/infrastructure/mythicmobs/exception/MythicMobSpawnException.java
@@ -18,7 +18,7 @@ public class MythicMobSpawnException extends SystemException {
      * MythicMobs 설정에서 해당 ID의 템플릿을 찾을 수 없을 때 발생합니다.
      *
      * @param mobId 찾을 수 없는 Mob ID
-     * @return {@link MythicMobSpawnException} 인스턴스
+     * @return 생성된 예외
      */
     @NonNull
     public static MythicMobSpawnException notFound(@NonNull String mobId) {
@@ -29,7 +29,7 @@ public class MythicMobSpawnException extends SystemException {
      * 플러그인 오류로 인해 엔티티 소환 결과가 null일 때 발생합니다.
      *
      * @param mobId 소환에 실패한 Mob ID
-     * @return {@link MythicMobSpawnException} 인스턴스
+     * @return 생성된 예외
      */
     @NonNull
     public static MythicMobSpawnException spawnFailed(@NonNull String mobId) {

--- a/src/main/java/dev/tecte/chessWar/port/notifier/SenderNotifier.java
+++ b/src/main/java/dev/tecte/chessWar/port/notifier/SenderNotifier.java
@@ -5,7 +5,7 @@ import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
 
 /**
- * 메시지를 전송합니다.
+ * 사용자에게 알림 및 안내 메시지를 전송합니다.
  */
 public interface SenderNotifier {
     /**

--- a/src/main/java/dev/tecte/chessWar/team/application/TeamNotifier.java
+++ b/src/main/java/dev/tecte/chessWar/team/application/TeamNotifier.java
@@ -1,0 +1,43 @@
+package dev.tecte.chessWar.team.application;
+
+import dev.tecte.chessWar.port.notifier.SenderNotifier;
+import dev.tecte.chessWar.team.domain.model.TeamColor;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+
+/**
+ * 팀 관련 알림 및 안내 메시지를 전송합니다.
+ */
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class TeamNotifier {
+    private final SenderNotifier senderNotifier;
+
+    /**
+     * 팀 참가 성공을 알립니다.
+     *
+     * @param recipient 알림을 받을 대상
+     * @param teamColor 참가한 팀의 색상
+     */
+    public void notifyJoin(@NonNull CommandSender recipient, @NonNull TeamColor teamColor) {
+        senderNotifier.notifySuccess(
+                recipient,
+                Component.text(teamColor.displayName(), teamColor.textColor())
+                        .append(Component.text("에 참가했습니다.", NamedTextColor.AQUA))
+        );
+    }
+
+    /**
+     * 팀 나가기 성공을 알립니다.
+     *
+     * @param recipient 알림을 받을 대상
+     */
+    public void notifyLeave(@NonNull CommandSender recipient) {
+        senderNotifier.notifySuccess(recipient, Component.text("팀에서 나갔습니다.", NamedTextColor.YELLOW));
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/team/application/port/TeamRepository.java
+++ b/src/main/java/dev/tecte/chessWar/team/application/port/TeamRepository.java
@@ -9,21 +9,20 @@ import java.util.UUID;
 
 /**
  * 팀의 영속성을 관리합니다.
- * 팀의 상태를 조회하거나 변경하는 메서드를 정의합니다.
  */
 public interface TeamRepository {
     /**
-     * 지정된 색상 팀의 현재 인원수를 조회합니다.
+     * 지정된 색상 팀의 현재 인원수를 확인합니다.
      *
-     * @param teamColor 조회할 팀의 색상
-     * @return 해당 팀의 현재 인원수
+     * @param teamColor 확인할 팀의 색상
+     * @return 현재 인원수
      */
     int getSize(@NonNull TeamColor teamColor);
 
     /**
-     * 팀의 최대 허용 인원수를 조회합니다.
+     * 팀의 최대 허용 인원수를 확인합니다.
      *
-     * @return 팀의 최대 인원수
+     * @return 최대 인원수
      */
     int getMaxPlayers();
 
@@ -31,32 +30,40 @@ public interface TeamRepository {
      * 팀의 최대 허용 인원수를 설정합니다.
      *
      * @param maxPlayers 설정할 최대 인원수
-     * @return 실제로 적용된 최대 인원수
+     * @return 적용된 최대 인원수
      */
     int setMaxPlayers(int maxPlayers);
 
     /**
      * 플레이어를 지정된 색상의 팀에 추가합니다.
      *
-     * @param playerId  팀에 추가할 플레이어의 UUID
-     * @param teamColor 플레이어가 추가될 팀의 색상
+     * @param playerId  추가할 플레이어의 ID
+     * @param teamColor 추가할 팀의 색상
      */
     void addPlayer(@NonNull UUID playerId, @NonNull TeamColor teamColor);
 
     /**
-     * 지정된 색상 팀에 속한 모든 플레이어의 UUID를 조회합니다.
+     * 플레이어를 팀에서 제거합니다.
      *
-     * @param teamColor 조회할 팀의 색상
-     * @return 해당 팀에 속한 모든 플레이어의 UUID 집합
+     * @param playerId 제거할 플레이어의 ID
+     * @return 제거 성공 여부
+     */
+    boolean removePlayer(@NonNull UUID playerId);
+
+    /**
+     * 지정된 색상 팀에 속한 모든 플레이어의 ID를 찾습니다.
+     *
+     * @param teamColor 찾을 팀의 색상
+     * @return 소속된 모든 플레이어의 ID
      */
     @NonNull
     Set<UUID> getPlayerUUIDs(@NonNull TeamColor teamColor);
 
     /**
-     * 플레이어가 속한 팀을 조회합니다.
+     * 플레이어가 속한 팀을 찾습니다.
      *
-     * @param playerId 조회할 플레이어의 UUID
-     * @return 플레이어가 속한 팀의 색상을 반환하고, 없으면 빈 {@link Optional}을 반환
+     * @param playerId 찾을 플레이어의 ID
+     * @return 찾은 팀의 색상
      */
     @NonNull
     Optional<TeamColor> findTeam(@NonNull UUID playerId);

--- a/src/main/java/dev/tecte/chessWar/team/domain/exception/TeamException.java
+++ b/src/main/java/dev/tecte/chessWar/team/domain/exception/TeamException.java
@@ -18,10 +18,20 @@ public class TeamException extends BusinessException {
      * 팀 정원 초과 시 사용자 알림 예외를 생성합니다.
      *
      * @param teamColor 정원이 가득 찬 팀
-     * @return {@link TeamException} 인스턴스
+     * @return 생성된 예외
      */
     @NonNull
     public static TeamException capacityExceeded(@NonNull TeamColor teamColor) {
         return new TeamException(teamColor.displayName() + "은 이미 가득 찼습니다.");
+    }
+
+    /**
+     * 참가 중인 팀이 없을 때 발생하는 예외를 생성합니다.
+     *
+     * @return 생성된 예외
+     */
+    @NonNull
+    public static TeamException notInTeam() {
+        return new TeamException("참가 중인 팀이 없습니다.");
     }
 }

--- a/src/main/java/dev/tecte/chessWar/team/infrastructure/command/TeamCommand.java
+++ b/src/main/java/dev/tecte/chessWar/team/infrastructure/command/TeamCommand.java
@@ -26,7 +26,7 @@ public class TeamCommand extends BaseCommand {
     private final TeamService teamService;
 
     /**
-     * 플레이어가 특정 팀에 참가합니다.
+     * 팀에 참가합니다.
      *
      * @param player    명령어를 실행한 플레이어
      * @param teamColor 참가할 팀의 색상
@@ -36,5 +36,16 @@ public class TeamCommand extends BaseCommand {
     @CommandCompletion("@teamcolors")
     public void join(@NonNull Player player, @NonNull TeamColor teamColor) {
         teamService.joinTeam(player, teamColor);
+    }
+
+    /**
+     * 팀에서 나갑니다.
+     *
+     * @param player 명령어를 실행한 플레이어
+     */
+    @Subcommand("leave")
+    @Description("팀에서 나갑니다.")
+    public void leave(@NonNull Player player) {
+        teamService.leaveTeam(player);
     }
 }

--- a/src/main/java/dev/tecte/chessWar/team/infrastructure/persistence/ScoreboardTeamRepository.java
+++ b/src/main/java/dev/tecte/chessWar/team/infrastructure/persistence/ScoreboardTeamRepository.java
@@ -1,8 +1,8 @@
 package dev.tecte.chessWar.team.infrastructure.persistence;
 
 import dev.tecte.chessWar.team.application.port.TeamRepository;
-import dev.tecte.chessWar.team.domain.model.TeamColor;
 import dev.tecte.chessWar.team.domain.model.TeamCapacityPolicy;
+import dev.tecte.chessWar.team.domain.model.TeamColor;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 
 /**
  * Scoreboard를 사용하여 팀 영속성을 관리합니다.
- * 팀 데이터를 Minecraft Scoreboard에 저장하고 관리합니다.
  */
 @Slf4j(topic = "ChessWar")
 @Singleton
@@ -80,6 +79,17 @@ public class ScoreboardTeamRepository implements TeamRepository {
                 .orElseGet(() -> createTeam(teamColor));
 
         team.addEntry(playerId.toString());
+    }
+
+    @Override
+    public boolean removePlayer(@NonNull UUID playerId) {
+        Team team = scoreboard.getEntryTeam(playerId.toString());
+
+        if (team == null || parseTeamColor(team.getName()).isEmpty()) {
+            return false;
+        }
+
+        return team.removeEntry(playerId.toString());
     }
 
     @NonNull


### PR DESCRIPTION
## Description
팀 나가기 기능(/team leave)을 구현하고, 시스템 전반의 알림 구조를 리팩토링했습니다. 또한, 프로젝트 Javadoc의 톤앤매너를 정비하고 서비스 로직의 응집도를 높여 코드 품질을 개선했습니다.

## Changes
✨ Feature: 팀 나가기 기능 구현
- TeamService: leaveTeam 메서드 추가 및 비즈니스 로직 구현
- TeamRepository: removePlayer 메서드 정의 및 스코어보드 구현체 반영
- TeamCommand: /team leave 서브 커맨드 추가
- TeamException: 팀 미소속 상태 예외 추가

♻️ Refactor: 알림 시스템 및 서비스 로직 개선
- Notifier 분리: TeamNotifier, BoardNotifier를 신설하여 알림 책임을 서비스에서 분리
- 상수 지역화: GameNotifier, PieceService, GameService의 설정을 메서드 내부 변수로 이동하여 응집도 향상
- 네이밍 개선: PieceSelectCommand를 PieceCommand로 변경하여 확장성 확보

📚 Docs: Javadoc 및 용어 표준화
- 용어 통일: "조회/검사" → "찾습니다", "식별자/UUID" → "ID"로 도메인 용어 정립
- 톤앤매너: 모든 서비스 및 리포지토리 주석을 간결하고 명확한 형태로 전면 재작성
- 정보 은닉: 기술적 구현 상세를 Public Javadoc에서 내부 주석으로 이동

## Test Checklist
- [x] /team join 및 /team leave 명령어가 의도대로 동작하는지 확인
- [x] 팀에서 나갈 시 적절한 성공 메시지("팀에서 나갔습니다.")가 출력되는지 확인
- [x] 팀에 속하지 않은 플레이어가 탈퇴 시도 시 예외 메시지가 정상 출력되는지 확인
- [x] 리팩토링된 BoardNotifier와 GameNotifier의 알림이 기존과 동일하게 작동하는지 확인
- [x] 전체 프로젝트의 빌드 및 테스트 통과 여부 확인

## Screenshots
| Team Leave Success | Team Leave Failure |
| :---: | :---: |
| <img width="853" height="478" alt="image" src="https://github.com/user-attachments/assets/b5446b31-3810-471f-abaa-2276b3e36a9a" /> | <img width="853" height="479" alt="image" src="https://github.com/user-attachments/assets/98bf0acf-b45c-4a4c-bea1-510594301a01" /> |