### PR TITLE
[Feat] Implement game phase timer system with BossBar and persistent state

### DIFF
--- a/src/main/java/dev/tecte/chessWar/game/application/GameAnnouncer.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/GameAnnouncer.java
@@ -2,7 +2,6 @@ package dev.tecte.chessWar.game.application;
 
 import dev.tecte.chessWar.game.application.port.GameRepository;
 import dev.tecte.chessWar.game.application.port.GameTaskManager;
-import dev.tecte.chessWar.game.domain.model.Game;
 import dev.tecte.chessWar.piece.domain.model.PieceType;
 import dev.tecte.chessWar.port.UserNotifier;
 import dev.tecte.chessWar.team.application.TeamService;
@@ -13,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -30,10 +28,27 @@ public class GameAnnouncer {
     /**
      * 기물 선택 시작을 알립니다.
      *
-     * @param targets 대상 참여자
+     * @param targets 대상 참가자 목록
      */
     public void announceSelectionStart(@NonNull Set<Player> targets) {
         targets.forEach(player -> userNotifier.displayTitle(player, GameMessage.SELECTION_TITLE.content()));
+    }
+
+    /**
+     * 현재 게임 상태에 맞게 기물 선택 가이드를 재개합니다.
+     */
+    public void restoreSelectionGuidance() {
+        gameRepository.find().ifPresent(game -> {
+            if (!game.isInSelectionPhase()) {
+                return;
+            }
+
+            if (game.hasSelectedPiece(teamService.findAllParticipantIds())) {
+                announceSelectionCompletion();
+            } else {
+                startSelectionGuidance();
+            }
+        });
     }
 
     /**
@@ -45,16 +60,46 @@ public class GameAnnouncer {
 
         gameTaskManager.runRepeating(
                 GameTaskType.GUIDANCE,
-                this::refreshSelectionStatus,
+                this::refreshParticipantsStatus,
                 initialDelay,
                 intervalTicks
         );
     }
 
     /**
+     * 기물 선택 가이드를 중단합니다.
+     */
+    public void stopGuidance() {
+        gameTaskManager.cancel(GameTaskType.GUIDANCE);
+    }
+
+    /**
+     * 기물 선택 상태를 반영하여 가이드를 즉시 새로고침합니다.
+     *
+     * @param player 대상 참가자
+     */
+    public void refreshSelectionStatus(@NonNull Player player) {
+        gameRepository.find().ifPresent(game -> {
+            if (!game.isInSelectionPhase()) {
+                return;
+            }
+
+            if (game.hasSelectedPiece(teamService.findAllParticipantIds())) {
+                userNotifier.displayActionBar(player, GameMessage.SELECTION_COMPLETED.content());
+
+                return;
+            }
+
+            boolean hasSelected = game.hasSelectedPiece(player.getUniqueId());
+
+            sendSelectionStatus(player, hasSelected);
+        });
+    }
+
+    /**
      * 기물 선택 완료를 알립니다.
      *
-     * @param player    대상 참여자
+     * @param player    대상 참가자
      * @param pieceType 선택된 기물 타입
      */
     public void notifyPieceSelection(@NonNull Player player, @NonNull PieceType pieceType) {
@@ -62,23 +107,16 @@ public class GameAnnouncer {
     }
 
     /**
-     * 기물 선택 상태를 반영하여 가이드를 갱신합니다.
-     *
-     * @param player 대상 참여자
+     * 모든 참가자의 기물 선택 완료를 알립니다.
      */
-    public void refreshSelectionStatus(@NonNull Player player) {
-        boolean hasSelected = gameRepository.find()
-                .map(game -> game.hasSelectedPiece(player.getUniqueId()))
-                .orElse(false);
-
-        sendSelectionStatus(player, hasSelected);
-    }
-
-    /**
-     * 기물 선택 안내를 중단합니다.
-     */
-    public void stopGuidance() {
-        gameTaskManager.cancel(GameTaskType.GUIDANCE);
+    public void announceSelectionCompletion() {
+        stopGuidance();
+        gameTaskManager.runRepeating(
+                GameTaskType.GUIDANCE,
+                this::displayCompletionStatus,
+                0L,
+                2 * 20L
+        );
     }
 
     /**
@@ -90,16 +128,13 @@ public class GameAnnouncer {
         userNotifier.informSuccess(requester, GameMessage.GAME_STOPPED.content());
     }
 
-    private void refreshSelectionStatus() {
-        Optional<Game> currentGame = gameRepository.find();
+    private void refreshParticipantsStatus() {
+        gameRepository.find().ifPresent(game ->
+                teamService.findAllOnlineParticipants().forEach(player -> {
+                    boolean hasSelected = game.hasSelectedPiece(player.getUniqueId());
 
-        teamService.findAllOnlineParticipants().forEach(player -> {
-            boolean hasSelected = currentGame
-                    .map(game -> game.hasSelectedPiece(player.getUniqueId()))
-                    .orElse(false);
-
-            sendSelectionStatus(player, hasSelected);
-        });
+                    sendSelectionStatus(player, hasSelected);
+                }));
     }
 
     private void sendSelectionStatus(@NonNull Player player, boolean hasSelected) {
@@ -107,5 +142,10 @@ public class GameAnnouncer {
                 player,
                 hasSelected ? GameMessage.SELECTION_WAITING.content() : GameMessage.SELECTION_GUIDE.content()
         );
+    }
+
+    private void displayCompletionStatus() {
+        teamService.findAllOnlineParticipants().forEach(player ->
+                userNotifier.displayActionBar(player, GameMessage.SELECTION_COMPLETED.content()));
     }
 }

--- a/src/main/java/dev/tecte/chessWar/game/application/GameFlowCoordinator.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/GameFlowCoordinator.java
@@ -14,6 +14,7 @@ import dev.tecte.chessWar.game.domain.exception.GameException;
 import dev.tecte.chessWar.game.domain.exception.GameSystemException;
 import dev.tecte.chessWar.game.domain.model.Game;
 import dev.tecte.chessWar.game.domain.model.GamePhase;
+import dev.tecte.chessWar.game.domain.model.PhaseTimerSettings;
 import dev.tecte.chessWar.game.domain.policy.GamePhaseTimerPolicy;
 import dev.tecte.chessWar.piece.application.PieceService;
 import dev.tecte.chessWar.piece.domain.model.UnitPiece;
@@ -33,7 +34,7 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * 게임의 생명주기와 비즈니스 흐름을 관리합니다.
+ * 게임의 전반적인 진행 흐름을 조율합니다.
  */
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
@@ -77,6 +78,7 @@ public class GameFlowCoordinator {
      * 게임을 중단합니다.
      *
      * @param sender 행위자
+     * @throws GameException 게임을 찾지 못했을 경우
      */
     public void stopGame(@NonNull CommandSender sender) {
         Game game = gameRepository.find().orElseThrow(GameException::notFound);
@@ -91,41 +93,42 @@ public class GameFlowCoordinator {
     /**
      * 전장을 준비합니다.
      *
-     * @param board     체스판 정보
+     * @param board     체스판
      * @param starterId 행위자 ID
      */
     public void prepareBattlefield(@NonNull Board board, @NonNull UUID starterId) {
         CommandSender starter = userResolver.resolveSender(starterId);
 
         pieceService.spawnPieces(board, starter)
-                .thenAccept(unitPlacements -> {
-                    Map<UUID, TeamColor> participants = teamService.findAllParticipants();
-
-                    eventDispatcher.dispatch(PiecesSpawnedEvent.of(
-                            board,
-                            unitPlacements,
-                            participants,
-                            starterId
-                    ));
-                });
+                .thenAccept(unitPlacements -> eventDispatcher.dispatch(
+                        PiecesSpawnedEvent.of(
+                                board,
+                                unitPlacements,
+                                teamService.findAllParticipants(),
+                                starterId
+                        )
+                ));
     }
 
     /**
      * 기물 선택 단계를 시작합니다.
      *
-     * @param unitPlacements 기물 배치 정보
-     * @param participants   참여자 정보
-     * @param starterId      행위자 ID
+     * @param initialPlacements 초기 기물 배치
+     * @param participants      참여자 정보
+     * @param starterId         행위자 ID
+     * @throws GameSystemException 단계 전이 실패 시
      */
     public void startSelectionPhase(
-            @NonNull Map<Coordinate, UnitPiece> unitPlacements,
+            @NonNull Map<Coordinate, UnitPiece> initialPlacements,
             @NonNull Map<UUID, TeamColor> participants,
             @NonNull UUID starterId
     ) {
         Game game = gameRepository.find()
                 .orElseThrow(() -> GameSystemException.gameTransitionInterrupted(GamePhase.PIECE_SELECTION));
+        PhaseTimerSettings timerSettings = timerPolicy.findSettings(GamePhase.PIECE_SELECTION)
+                .orElseThrow(() -> GameSystemException.gameTransitionInterrupted(GamePhase.PIECE_SELECTION));
 
-        game = game.startSelection(unitPlacements);
+        game = game.startSelection(initialPlacements, timerSettings);
         gameRepository.save(game);
         eventDispatcher.dispatch(GameSelectionStartedEvent.of(
                 game,
@@ -135,17 +138,22 @@ public class GameFlowCoordinator {
     }
 
     /**
-     * 타이머를 시작합니다.
+     * 게임 단계에 맞는 타이머를 활성화합니다.
      *
-     * @param phase          게임 단계
+     * @param game           대상 게임
      * @param participantIds 참여자 ID 목록
      */
-    public void initiatePhaseTimer(
-            @NonNull GamePhase phase,
-            @NonNull Collection<UUID> participantIds
-    ) {
-        timerPolicy.findSettings(phase)
-                .ifPresent(settings -> timerService.start(phase, settings, participantIds));
+    public void initiatePhaseTimer(@NonNull Game game, @NonNull Collection<UUID> participantIds) {
+        game.timedState()
+                .ifPresent(timedState -> timerService.start(game.phase(), timedState, participantIds));
+    }
+
+    /**
+     * 진행 중인 게임의 타이머를 복구합니다.
+     */
+    public void resumeActiveGameTimer() {
+        gameRepository.find()
+                .ifPresent(game -> initiatePhaseTimer(game, teamService.findAllParticipantIds()));
     }
 
     /**
@@ -154,14 +162,13 @@ public class GameFlowCoordinator {
      * @param player 접속한 플레이어
      */
     public void handlePlayerJoin(@NonNull Player player) {
-        teamService.findTeam(player).ifPresent(teamColor ->
-                gameRepository.find().ifPresent(game ->
-                        eventDispatcher.dispatch(GameParticipantJoinedEvent.of(
+        teamService.findTeam(player)
+                .flatMap(teamColor -> gameRepository.find()
+                        .map(game -> GameParticipantJoinedEvent.of(
                                 player.getUniqueId(),
                                 teamColor,
                                 game.unitPlacements()
-                        ))
-                )
-        );
+                        )))
+                .ifPresent(eventDispatcher::dispatch);
     }
 }

--- a/src/main/java/dev/tecte/chessWar/game/application/GameFlowCoordinator.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/GameFlowCoordinator.java
@@ -14,6 +14,7 @@ import dev.tecte.chessWar.game.domain.exception.GameException;
 import dev.tecte.chessWar.game.domain.exception.GameSystemException;
 import dev.tecte.chessWar.game.domain.model.Game;
 import dev.tecte.chessWar.game.domain.model.GamePhase;
+import dev.tecte.chessWar.game.domain.policy.GamePhaseTimerPolicy;
 import dev.tecte.chessWar.piece.application.PieceService;
 import dev.tecte.chessWar.piece.domain.model.UnitPiece;
 import dev.tecte.chessWar.port.UserResolver;
@@ -27,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 
@@ -36,7 +38,9 @@ import java.util.UUID;
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class GameFlowCoordinator {
+    private final GamePhaseTimerPolicy timerPolicy;
     private final GameRepository gameRepository;
+    private final GameTimerService timerService;
     private final BoardService boardService;
     private final TeamService teamService;
     private final PieceService pieceService;
@@ -121,12 +125,27 @@ public class GameFlowCoordinator {
         Game game = gameRepository.find()
                 .orElseThrow(() -> GameSystemException.gameTransitionInterrupted(GamePhase.PIECE_SELECTION));
 
-        gameRepository.save(game.startSelection(unitPlacements));
+        game = game.startSelection(unitPlacements);
+        gameRepository.save(game);
         eventDispatcher.dispatch(GameSelectionStartedEvent.of(
                 game,
                 participants,
                 starterId
         ));
+    }
+
+    /**
+     * 타이머를 시작합니다.
+     *
+     * @param phase          게임 단계
+     * @param participantIds 참여자 ID 목록
+     */
+    public void initiatePhaseTimer(
+            @NonNull GamePhase phase,
+            @NonNull Collection<UUID> participantIds
+    ) {
+        timerPolicy.findSettings(phase)
+                .ifPresent(settings -> timerService.start(phase, settings, participantIds));
     }
 
     /**

--- a/src/main/java/dev/tecte/chessWar/game/application/GameFlowCoordinator.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/GameFlowCoordinator.java
@@ -138,6 +138,19 @@ public class GameFlowCoordinator {
     }
 
     /**
+     * 기물 선택 완료 시 타이머를 단축합니다.
+     *
+     * @throws GameSystemException 게임 정보를 찾을 수 없을 경우
+     */
+    public void accelerateSelectionTimer() {
+        Game game = gameRepository.find()
+                .orElseThrow(() -> GameSystemException.gameNotFound(GamePhase.PIECE_SELECTION));
+
+        timerService.accelerate();
+        gameRepository.save(game);
+    }
+
+    /**
      * 게임 단계에 맞는 타이머를 활성화합니다.
      *
      * @param game           대상 게임

--- a/src/main/java/dev/tecte/chessWar/game/application/GameMessage.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/GameMessage.java
@@ -10,7 +10,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 
 /**
- * 게임 진행 중 참여자에게 전달할 고정 메시지 목록입니다.
+ * 게임 진행 중 참가자에게 전달할 메시지 목록입니다.
  */
 @Getter
 @Accessors(fluent = true)
@@ -24,6 +24,9 @@ public enum GameMessage {
     ),
     SELECTION_WAITING(
             Component.text("기물 선택 완료! 다른 플레이어를 기다리는 중...").color(NamedTextColor.GREEN)
+    ),
+    SELECTION_COMPLETED(
+            Component.text("기물 선택이 모두 완료되었습니다!").color(NamedTextColor.AQUA)
     ),
     GAME_STOPPED(
             Component.text("게임이 중단되었습니다.")

--- a/src/main/java/dev/tecte/chessWar/game/application/GameTaskType.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/GameTaskType.java
@@ -4,7 +4,6 @@ package dev.tecte.chessWar.game.application;
  * 제어 가능한 게임 태스크의 역할을 정의합니다.
  */
 public enum GameTaskType {
-    GUIDANCE,
-    PHASE_TRANSITION,
-    GAME_CLEANUP
+    TIMER,
+    GUIDANCE
 }

--- a/src/main/java/dev/tecte/chessWar/game/application/GameTimerService.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/GameTimerService.java
@@ -6,22 +6,19 @@ import dev.tecte.chessWar.game.application.port.GameTaskManager;
 import dev.tecte.chessWar.game.application.port.GameTimerDisplay;
 import dev.tecte.chessWar.game.domain.event.GamePhaseExpiredEvent;
 import dev.tecte.chessWar.game.domain.model.GamePhase;
-import dev.tecte.chessWar.game.domain.model.PhaseTimerSettings;
+import dev.tecte.chessWar.game.domain.model.phase.TimedState;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import net.kyori.adventure.bossbar.BossBar;
-import net.kyori.adventure.text.Component;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * 게임 타이머를 관리합니다.
+ * 게임 단계별 타이머의 생명주기를 관리합니다.
  */
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
@@ -38,34 +35,39 @@ public class GameTimerService {
      * 타이머를 시작합니다.
      *
      * @param phase          게임 단계
-     * @param settings       타이머 설정
+     * @param state          타이머 상태
      * @param participantIds 참여자 ID 목록
      */
     public void start(
             @NonNull GamePhase phase,
-            @NonNull PhaseTimerSettings settings,
+            @NonNull TimedState state,
             @NonNull Collection<UUID> participantIds
     ) {
         stop();
-        currentSession = TimerSession.of(phase, settings);
 
-        Component initialTitle = settings.visuals().renderTitle(phase.displayName(), settings.duration());
-
-        timerDisplay.show(participantIds, initialTitle, BossBar.MAX_PROGRESS);
+        currentSession = TimerSession.of(state.timerSettings(), phase, state.remainingTime());
+        timerDisplay.show(participantIds, currentSession.renderTitle(), currentSession.progress());
         taskManager.runRepeating(GameTaskType.TIMER, this::tick, 0L, TICKS_PER_SECOND);
     }
 
     /**
-     * 타이머를 복구하여 보여줍니다.
+     * 타이머를 중단합니다.
+     */
+    public void stop() {
+        taskManager.cancel(GameTaskType.TIMER);
+        timerDisplay.hide();
+        currentSession = null;
+    }
+
+    /**
+     * 타이머 표시를 복구합니다.
      *
      * @param playerId 플레이어 ID
      */
     public void restore(@NonNull UUID playerId) {
-        if (!isActive()) {
-            return;
+        if (isActive()) {
+            timerDisplay.show(playerId);
         }
-
-        timerDisplay.show(playerId);
     }
 
     /**
@@ -78,12 +80,13 @@ public class GameTimerService {
     }
 
     /**
-     * 타이머를 중단합니다.
+     * 남은 시간을 제공합니다.
+     *
+     * @return 남은 시간
      */
-    public void stop() {
-        taskManager.cancel(GameTaskType.TIMER);
-        timerDisplay.hide();
-        currentSession = null;
+    @NonNull
+    public Optional<Duration> remainingTime() {
+        return isActive() ? Optional.of(currentSession.remainingTime()) : Optional.empty();
     }
 
     private void tick() {
@@ -93,44 +96,19 @@ public class GameTimerService {
             return;
         }
 
-        GamePhase phase = session.phase();
-        int secondsLeft = session.remainingSeconds().decrementAndGet();
+        int secondsLeft = session.tick();
 
         if (secondsLeft <= 0) {
-            handleTimeout(phase);
+            handleTimeout(session.phase());
 
             return;
         }
 
-        PhaseTimerSettings settings = session.settings();
-        double progress = (double) secondsLeft / settings.duration().toSeconds();
-        Component title = settings.visuals().renderTitle(phase.displayName(), Duration.ofSeconds(secondsLeft));
-
-        timerDisplay.update(title, progress);
+        timerDisplay.update(session.renderTitle(), session.progress());
     }
 
     private void handleTimeout(@NonNull GamePhase phase) {
         stop();
         eventDispatcher.dispatch(GamePhaseExpiredEvent.of(phase, ProjectIdentity.SYSTEM_ID));
-    }
-
-    private record TimerSession(
-            @NonNull GamePhase phase,
-            @NonNull PhaseTimerSettings settings,
-            @NonNull AtomicInteger remainingSeconds
-    ) {
-        private TimerSession {
-            Objects.requireNonNull(phase, "Phase cannot be null");
-            Objects.requireNonNull(settings, "Settings cannot be null");
-            Objects.requireNonNull(remainingSeconds, "Remaining seconds cannot be null");
-        }
-
-        static TimerSession of(GamePhase phase, PhaseTimerSettings settings) {
-            return new TimerSession(
-                    phase,
-                    settings,
-                    new AtomicInteger((int) settings.duration().toSeconds())
-            );
-        }
     }
 }

--- a/src/main/java/dev/tecte/chessWar/game/application/GameTimerService.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/GameTimerService.java
@@ -7,7 +7,6 @@ import dev.tecte.chessWar.game.application.port.GameTimerDisplay;
 import dev.tecte.chessWar.game.domain.event.GamePhaseExpiredEvent;
 import dev.tecte.chessWar.game.domain.model.GamePhase;
 import dev.tecte.chessWar.game.domain.model.PhaseTimerSettings;
-import dev.tecte.chessWar.game.domain.model.TimerVisuals;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -17,6 +16,7 @@ import net.kyori.adventure.text.Component;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -32,8 +32,7 @@ public class GameTimerService {
     private final GameTimerDisplay timerDisplay;
     private final DomainEventDispatcher eventDispatcher;
 
-    private final AtomicInteger remainingSeconds = new AtomicInteger(0);
-    private GamePhase currentPhase;
+    private TimerSession currentSession;
 
     /**
      * 타이머를 시작합니다.
@@ -48,16 +47,34 @@ public class GameTimerService {
             @NonNull Collection<UUID> participantIds
     ) {
         stop();
-        currentPhase = phase;
+        currentSession = TimerSession.of(phase, settings);
 
-        Duration duration = settings.duration();
-        int total = (int) duration.toSeconds();
-        TimerVisuals visuals = settings.visuals();
-        Component initialTitle = visuals.renderTitle(phase.displayName(), duration);
+        Component initialTitle = settings.visuals().renderTitle(phase.displayName(), settings.duration());
 
-        remainingSeconds.set(total);
         timerDisplay.show(participantIds, initialTitle, BossBar.MAX_PROGRESS);
-        taskManager.runRepeating(GameTaskType.TIMER, () -> tick(total, visuals), 0L, TICKS_PER_SECOND);
+        taskManager.runRepeating(GameTaskType.TIMER, this::tick, 0L, TICKS_PER_SECOND);
+    }
+
+    /**
+     * 타이머를 복구하여 보여줍니다.
+     *
+     * @param playerId 플레이어 ID
+     */
+    public void restore(@NonNull UUID playerId) {
+        if (!isActive()) {
+            return;
+        }
+
+        timerDisplay.show(playerId);
+    }
+
+    /**
+     * 타이머 활성화 여부를 확인합니다.
+     *
+     * @return 활성화 여부
+     */
+    public boolean isActive() {
+        return currentSession != null;
     }
 
     /**
@@ -66,25 +83,54 @@ public class GameTimerService {
     public void stop() {
         taskManager.cancel(GameTaskType.TIMER);
         timerDisplay.hide();
+        currentSession = null;
     }
 
-    private void tick(int total, @NonNull TimerVisuals visuals) {
-        int left = remainingSeconds.decrementAndGet();
+    private void tick() {
+        TimerSession session = currentSession;
 
-        if (left <= 0) {
-            handleTimeout();
+        if (session == null) {
+            return;
+        }
+
+        GamePhase phase = session.phase();
+        int secondsLeft = session.remainingSeconds().decrementAndGet();
+
+        if (secondsLeft <= 0) {
+            handleTimeout(phase);
 
             return;
         }
 
-        double progress = (double) left / total;
-        Component title = visuals.renderTitle(currentPhase.displayName(), Duration.ofSeconds(left));
+        PhaseTimerSettings settings = session.settings();
+        double progress = (double) secondsLeft / settings.duration().toSeconds();
+        Component title = settings.visuals().renderTitle(phase.displayName(), Duration.ofSeconds(secondsLeft));
 
         timerDisplay.update(title, progress);
     }
 
-    private void handleTimeout() {
+    private void handleTimeout(@NonNull GamePhase phase) {
         stop();
-        eventDispatcher.dispatch(GamePhaseExpiredEvent.of(currentPhase, ProjectIdentity.SYSTEM_ID));
+        eventDispatcher.dispatch(GamePhaseExpiredEvent.of(phase, ProjectIdentity.SYSTEM_ID));
+    }
+
+    private record TimerSession(
+            @NonNull GamePhase phase,
+            @NonNull PhaseTimerSettings settings,
+            @NonNull AtomicInteger remainingSeconds
+    ) {
+        private TimerSession {
+            Objects.requireNonNull(phase, "Phase cannot be null");
+            Objects.requireNonNull(settings, "Settings cannot be null");
+            Objects.requireNonNull(remainingSeconds, "Remaining seconds cannot be null");
+        }
+
+        static TimerSession of(GamePhase phase, PhaseTimerSettings settings) {
+            return new TimerSession(
+                    phase,
+                    settings,
+                    new AtomicInteger((int) settings.duration().toSeconds())
+            );
+        }
     }
 }

--- a/src/main/java/dev/tecte/chessWar/game/application/GameTimerService.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/GameTimerService.java
@@ -1,0 +1,90 @@
+package dev.tecte.chessWar.game.application;
+
+import dev.tecte.chessWar.common.event.DomainEventDispatcher;
+import dev.tecte.chessWar.common.identity.ProjectIdentity;
+import dev.tecte.chessWar.game.application.port.GameTaskManager;
+import dev.tecte.chessWar.game.application.port.GameTimerDisplay;
+import dev.tecte.chessWar.game.domain.event.GamePhaseExpiredEvent;
+import dev.tecte.chessWar.game.domain.model.GamePhase;
+import dev.tecte.chessWar.game.domain.model.PhaseTimerSettings;
+import dev.tecte.chessWar.game.domain.model.TimerVisuals;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 게임 타이머를 관리합니다.
+ */
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class GameTimerService {
+    private static final long TICKS_PER_SECOND = 20L;
+
+    private final GameTaskManager taskManager;
+    private final GameTimerDisplay timerDisplay;
+    private final DomainEventDispatcher eventDispatcher;
+
+    private final AtomicInteger remainingSeconds = new AtomicInteger(0);
+    private GamePhase currentPhase;
+
+    /**
+     * 타이머를 시작합니다.
+     *
+     * @param phase          게임 단계
+     * @param settings       타이머 설정
+     * @param participantIds 참여자 ID 목록
+     */
+    public void start(
+            @NonNull GamePhase phase,
+            @NonNull PhaseTimerSettings settings,
+            @NonNull Collection<UUID> participantIds
+    ) {
+        stop();
+        currentPhase = phase;
+
+        Duration duration = settings.duration();
+        int total = (int) duration.toSeconds();
+        TimerVisuals visuals = settings.visuals();
+        Component initialTitle = visuals.renderTitle(phase.displayName(), duration);
+
+        remainingSeconds.set(total);
+        timerDisplay.show(participantIds, initialTitle, BossBar.MAX_PROGRESS);
+        taskManager.runRepeating(GameTaskType.TIMER, () -> tick(total, visuals), 0L, TICKS_PER_SECOND);
+    }
+
+    /**
+     * 타이머를 중단합니다.
+     */
+    public void stop() {
+        taskManager.cancel(GameTaskType.TIMER);
+        timerDisplay.hide();
+    }
+
+    private void tick(int total, @NonNull TimerVisuals visuals) {
+        int left = remainingSeconds.decrementAndGet();
+
+        if (left <= 0) {
+            handleTimeout();
+
+            return;
+        }
+
+        double progress = (double) left / total;
+        Component title = visuals.renderTitle(currentPhase.displayName(), Duration.ofSeconds(left));
+
+        timerDisplay.update(title, progress);
+    }
+
+    private void handleTimeout() {
+        stop();
+        eventDispatcher.dispatch(GamePhaseExpiredEvent.of(currentPhase, ProjectIdentity.SYSTEM_ID));
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/game/application/GameTimerService.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/GameTimerService.java
@@ -6,6 +6,7 @@ import dev.tecte.chessWar.game.application.port.GameTaskManager;
 import dev.tecte.chessWar.game.application.port.GameTimerDisplay;
 import dev.tecte.chessWar.game.domain.event.GamePhaseExpiredEvent;
 import dev.tecte.chessWar.game.domain.model.GamePhase;
+import dev.tecte.chessWar.game.domain.model.TimerSession;
 import dev.tecte.chessWar.game.domain.model.phase.TimedState;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -36,7 +37,7 @@ public class GameTimerService {
      *
      * @param phase          게임 단계
      * @param state          타이머 상태
-     * @param participantIds 참여자 ID 목록
+     * @param participantIds 참가자 ID 목록
      */
     public void start(
             @NonNull GamePhase phase,
@@ -62,11 +63,33 @@ public class GameTimerService {
     /**
      * 타이머 표시를 복구합니다.
      *
-     * @param playerId 플레이어 ID
+     * @param participantId 참가자 ID
      */
-    public void restore(@NonNull UUID playerId) {
+    public void restore(@NonNull UUID participantId) {
         if (isActive()) {
-            timerDisplay.show(playerId);
+            timerDisplay.show(participantId);
+        }
+    }
+
+    /**
+     * 현재 활성화된 타이머를 설정된 제한 시간으로 단축합니다.
+     */
+    public void accelerate() {
+        if (isActive()) {
+            accelerate(currentSession.reducedDuration());
+        }
+    }
+
+    /**
+     * 타이머를 특정 시간으로 단축합니다.
+     *
+     * @param reducedTime 목표 제한 시간
+     */
+    public void accelerate(@NonNull Duration reducedTime) {
+        int reducedSeconds = (int) reducedTime.toSeconds();
+
+        if (isActive() && currentSession.accelerateTo(reducedSeconds)) {
+            timerDisplay.update(currentSession.renderTitle(), currentSession.progress());
         }
     }
 

--- a/src/main/java/dev/tecte/chessWar/game/application/PieceSelectionCoordinator.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/PieceSelectionCoordinator.java
@@ -2,6 +2,7 @@ package dev.tecte.chessWar.game.application;
 
 import dev.tecte.chessWar.common.event.DomainEventDispatcher;
 import dev.tecte.chessWar.game.application.port.GameRepository;
+import dev.tecte.chessWar.game.domain.event.AllParticipantsSelectedEvent;
 import dev.tecte.chessWar.game.domain.event.PieceSelectedEvent;
 import dev.tecte.chessWar.game.domain.exception.GameException;
 import dev.tecte.chessWar.game.domain.exception.GameSystemException;
@@ -57,23 +58,29 @@ public class PieceSelectionCoordinator {
     }
 
     /**
-     * 기물을 선택하여 참전을 완료합니다.
+     * 기물을 선택하여 참전합니다.
      *
-     * @param player  플레이어
+     * @param player  참가자
      * @param pieceId 기물 ID
      */
     public void selectPiece(@NonNull Player player, @NonNull UUID pieceId) {
         Game game = gameRepository.find().orElseThrow(GameException::notFound);
         Piece piece = game.findPiece(pieceId).orElseThrow(GameException::pieceNotFound);
 
+        game = game.selectPiece(player.getUniqueId(), pieceId);
+
         try {
-            gameRepository.save(game.selectPiece(player.getUniqueId(), pieceId));
+            gameRepository.save(game);
         } catch (PersistenceException e) {
             throw GameSystemException.pieceSelectionFailed(pieceId, e);
         }
 
         applyPieceStats(player, piece.spec());
         eventDispatcher.dispatch(PieceSelectedEvent.of(player.getUniqueId(), pieceId, piece.spec()));
+
+        if (game.hasSelectedPiece(teamService.findAllParticipantIds())) {
+            eventDispatcher.dispatch(AllParticipantsSelectedEvent.create());
+        }
     }
 
     /**

--- a/src/main/java/dev/tecte/chessWar/game/application/TimerSession.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/TimerSession.java
@@ -1,0 +1,88 @@
+package dev.tecte.chessWar.game.application;
+
+import dev.tecte.chessWar.game.domain.model.GamePhase;
+import dev.tecte.chessWar.game.domain.model.PhaseTimerSettings;
+import lombok.NonNull;
+import net.kyori.adventure.text.Component;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 진행 중인 타이머 세션의 상태를 나타냅니다.
+ *
+ * @param timerSettings    타이머 설정
+ * @param phase            게임 단계
+ * @param remainingSeconds 남은 초
+ */
+record TimerSession(
+        PhaseTimerSettings timerSettings,
+        GamePhase phase,
+        AtomicInteger remainingSeconds
+) {
+    TimerSession {
+        Objects.requireNonNull(timerSettings, "Settings cannot be null");
+        Objects.requireNonNull(phase, "Phase cannot be null");
+        Objects.requireNonNull(remainingSeconds, "Remaining seconds cannot be null");
+    }
+
+    /**
+     * 타이머 세션을 생성합니다.
+     *
+     * @param timerSettings 타이머 설정
+     * @param phase         게임 단계
+     * @param remainingTime 남은 시간
+     * @return 타이머 세션
+     */
+    @NonNull
+    public static TimerSession of(
+            @NonNull PhaseTimerSettings timerSettings,
+            @NonNull GamePhase phase,
+            @NonNull Duration remainingTime
+    ) {
+        return new TimerSession(
+                timerSettings,
+                phase,
+                new AtomicInteger((int) remainingTime.toSeconds())
+        );
+    }
+
+    /**
+     * 시간을 1초 감소시킵니다.
+     *
+     * @return 남은 초
+     */
+    public int tick() {
+        return remainingSeconds.decrementAndGet();
+    }
+
+    /**
+     * 현재 남은 시간을 제공합니다.
+     *
+     * @return 남은 시간
+     */
+    @NonNull
+    public Duration remainingTime() {
+        return Duration.ofSeconds(remainingSeconds.get());
+    }
+
+    /**
+     * 타이머 진행률을 산출합니다.
+     *
+     * @return 진행률
+     */
+    public double progress() {
+        return (double) remainingSeconds.get() / timerSettings.totalSeconds();
+    }
+
+    /**
+     * 타이머 제목을 렌더링합니다.
+     *
+     * @return 제목
+     */
+    @NonNull
+    public Component renderTitle() {
+        return timerSettings.renderTitle(phase.displayName(), remainingTime());
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/game/application/port/GameTimerDisplay.java
+++ b/src/main/java/dev/tecte/chessWar/game/application/port/GameTimerDisplay.java
@@ -1,0 +1,45 @@
+package dev.tecte.chessWar.game.application.port;
+
+import lombok.NonNull;
+import net.kyori.adventure.text.Component;
+
+import java.util.Collection;
+import java.util.UUID;
+
+/**
+ * 게임 타이머의 표시를 관리합니다.
+ */
+public interface GameTimerDisplay {
+    /**
+     * 타이머를 보여줍니다.
+     *
+     * @param targetIds 플레이어 ID 목록
+     * @param title     제목
+     * @param progress  진행률
+     */
+    void show(
+            @NonNull Collection<UUID> targetIds,
+            @NonNull Component title,
+            double progress
+    );
+
+    /**
+     * 타이머를 보여줍니다.
+     *
+     * @param playerId 플레이어 ID
+     */
+    void show(@NonNull UUID playerId);
+
+    /**
+     * 타이머 상태를 업데이트합니다.
+     *
+     * @param title    제목
+     * @param progress 진행률
+     */
+    void update(@NonNull Component title, double progress);
+
+    /**
+     * 타이머를 숨깁니다.
+     */
+    void hide();
+}

--- a/src/main/java/dev/tecte/chessWar/game/domain/event/AllParticipantsSelectedEvent.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/event/AllParticipantsSelectedEvent.java
@@ -1,0 +1,50 @@
+package dev.tecte.chessWar.game.domain.event;
+
+import dev.tecte.chessWar.common.event.DomainEvent;
+import dev.tecte.chessWar.common.identity.ProjectIdentity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+/**
+ * 모든 참가자가 기물 선택을 완료했을 때 발생합니다.
+ */
+@Getter
+@Accessors(fluent = true)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class AllParticipantsSelectedEvent extends DomainEvent {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    /**
+     * 모든 참가자의 기물 선택 완료 이벤트를 생성합니다.
+     *
+     * @return 기물 선택 완료 이벤트
+     */
+    @NonNull
+    public static AllParticipantsSelectedEvent create() {
+        return new AllParticipantsSelectedEvent();
+    }
+
+    @NonNull
+    @Override
+    public UUID senderId() {
+        return ProjectIdentity.SYSTEM_ID;
+    }
+
+    @NonNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @NonNull
+    @SuppressWarnings("unused")
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/game/domain/event/GamePhaseExpiredEvent.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/event/GamePhaseExpiredEvent.java
@@ -1,0 +1,55 @@
+package dev.tecte.chessWar.game.domain.event;
+
+import dev.tecte.chessWar.common.event.DomainEvent;
+import dev.tecte.chessWar.game.domain.model.GamePhase;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+/**
+ * 특정 게임 단계의 제한 시간이 만료되었음을 기록합니다.
+ */
+@Getter
+@Accessors(fluent = true)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class GamePhaseExpiredEvent extends DomainEvent {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final GamePhase expiredPhase;
+    private final UUID senderId;
+
+    /**
+     * 단계 만료 이벤트를 생성합니다.
+     *
+     * @param expiredPhase 만료된 단계
+     * @param senderId     행위자 ID
+     * @return 단계 만료 이벤트
+     */
+    @NonNull
+    public static GamePhaseExpiredEvent of(@NonNull GamePhase expiredPhase, @NonNull UUID senderId) {
+        return new GamePhaseExpiredEvent(expiredPhase, senderId);
+    }
+
+    @NonNull
+    @Override
+    public UUID senderId() {
+        return senderId;
+    }
+
+    @NonNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @NonNull
+    @SuppressWarnings("unused")
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/game/domain/exception/GameSystemException.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/exception/GameSystemException.java
@@ -26,6 +26,20 @@ public class GameSystemException extends NotifiableSystemException {
     }
 
     /**
+     * 진행 중인 게임 정보를 찾을 수 없을 때 발생합니다.
+     *
+     * @param phase 현재 오류가 발생한 단계
+     * @return 생성된 예외
+     */
+    @NonNull
+    public static GameSystemException gameNotFound(@NonNull GamePhase phase) {
+        return new GameSystemException(
+                "Active game instance not found [Phase: %s]".formatted(phase.name()),
+                "시스템 오류로 게임 정보를 찾을 수 없어 진행에 실패했습니다."
+        );
+    }
+
+    /**
      * 게임 단계 전환이 중단되었을 때 발생합니다.
      *
      * @param targetPhase 대상 단계

--- a/src/main/java/dev/tecte/chessWar/game/domain/model/Game.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/model/Game.java
@@ -6,10 +6,12 @@ import dev.tecte.chessWar.game.domain.exception.GameException;
 import dev.tecte.chessWar.game.domain.model.phase.PhaseState;
 import dev.tecte.chessWar.game.domain.model.phase.SelectionState;
 import dev.tecte.chessWar.game.domain.model.phase.SetupState;
+import dev.tecte.chessWar.game.domain.model.phase.TimedState;
 import dev.tecte.chessWar.piece.domain.model.Piece;
 import dev.tecte.chessWar.piece.domain.model.UnitPiece;
 import lombok.NonNull;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,11 +21,11 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
- * 게임 상태와 페이즈 전이를 제어하는 애그리거트 루트입니다.
+ * 게임의 진행 상태와 단계 전이를 관리하는 애그리거트 루트입니다.
  *
- * @param board  게임이 진행되는 체스판
- * @param pieces 체스판의 기물 배치 현황
- * @param state  현재 단계별 상태 데이터
+ * @param board  체스판
+ * @param pieces 기물 배치
+ * @param state  단계별 상태
  */
 public record Game(
         Board board,
@@ -42,20 +44,20 @@ public record Game(
      * 초기 준비 상태의 게임을 생성합니다.
      *
      * @param board 체스판
-     * @return 초기화된 게임
+     * @return 게임
      */
     @NonNull
     public static Game create(@NonNull Board board) {
-        return new Game(board, new HashMap<>(), SetupState.empty());
+        return new Game(board, new HashMap<>(), SetupState.initial());
     }
 
     /**
-     * 주어진 상태로 게임을 생성합니다.
+     * 게임을 생성합니다.
      *
      * @param board  체스판
      * @param pieces 기물 배치
-     * @param state  단계별 상태 데이터
-     * @return 생성된 게임
+     * @param state  단계별 상태
+     * @return 게임
      */
     @NonNull
     public static Game of(
@@ -67,36 +69,40 @@ public record Game(
     }
 
     /**
-     * 기물 선택 단계로 전이합니다.
+     * 기물 선택 단계를 시작합니다.
      *
-     * @param spawnedPieces 배치된 기물 정보
+     * @param initialPlacements 초기 기물 배치
+     * @param timerSettings     타이머 설정
      * @return 업데이트된 게임
      * @throws GameException 준비 단계가 아닐 경우
      */
     @NonNull
-    public Game startSelection(@NonNull Map<Coordinate, ? extends Piece> spawnedPieces) {
-        if (phase() != GamePhase.SETUP) {
+    public Game startSelection(
+            @NonNull Map<Coordinate, UnitPiece> initialPlacements,
+            @NonNull PhaseTimerSettings timerSettings
+    ) {
+        if (!(state instanceof SetupState)) {
             throw GameException.phaseMismatch(GamePhase.SETUP, phase());
         }
 
         Map<Coordinate, Piece> newPieces = new HashMap<>(pieces);
 
-        newPieces.putAll(spawnedPieces);
+        newPieces.putAll(initialPlacements);
 
-        return new Game(board, newPieces, SelectionState.empty());
+        return new Game(board, newPieces, SelectionState.initial(timerSettings));
     }
 
     /**
-     * 플레이어의 기물 선택 결과를 반영합니다.
+     * 플레이어의 기물 선택을 반영합니다.
      *
      * @param playerId 플레이어 ID
      * @param pieceId  기물 ID
      * @return 업데이트된 게임
-     * @throws GameException 단계 불일치, 기물 미발견 또는 중복 선택 시
+     * @throws GameException 단계 불일치, 기물 미발견, 선택 불가 또는 이미 선택된 경우
      */
     @NonNull
     public Game selectPiece(@NonNull UUID playerId, @NonNull UUID pieceId) {
-        if (phase() != GamePhase.PIECE_SELECTION) {
+        if (!(state instanceof SelectionState selection)) {
             throw GameException.phaseMismatch(GamePhase.PIECE_SELECTION, phase());
         }
 
@@ -110,11 +116,24 @@ public record Game(
             throw GameException.pieceAlreadySelected();
         }
 
-        return new Game(board, pieces, ((SelectionState) state).withSelection(playerId, pieceId));
+        return atState(selection.select(playerId, pieceId));
     }
 
     /**
-     * 현재 게임 단계를 제공합니다.
+     * 남은 시간이 업데이트된 게임을 제공합니다.
+     *
+     * @param remainingTime 남은 시간
+     * @return 업데이트된 게임
+     */
+    @NonNull
+    public Game remaining(@NonNull Duration remainingTime) {
+        return (state instanceof TimedState timedState)
+                ? atState(timedState.remaining(remainingTime))
+                : this;
+    }
+
+    /**
+     * 현재 단계를 제공합니다.
      *
      * @return 현재 단계
      */
@@ -124,16 +143,26 @@ public record Game(
     }
 
     /**
+     * 타이머 상태를 제공합니다.
+     *
+     * @return 타이머 상태
+     */
+    @NonNull
+    public Optional<TimedState> timedState() {
+        return (state instanceof TimedState timedState) ? Optional.of(timedState) : Optional.empty();
+    }
+
+    /**
      * 현재 기물 선택 단계인지 확인합니다.
      *
      * @return 기물 선택 단계 여부
      */
     public boolean isInSelectionPhase() {
-        return phase() == GamePhase.PIECE_SELECTION;
+        return state instanceof SelectionState;
     }
 
     /**
-     * ID 기반으로 체스판의 기물을 검색합니다.
+     * ID로 기물을 검색합니다.
      *
      * @param pieceId 기물 ID
      * @return 찾은 기물
@@ -146,35 +175,27 @@ public record Game(
     }
 
     /**
-     * 기물의 선택 여부를 확인합니다.
+     * 기물이 이미 선택되었는지 확인합니다.
      *
      * @param pieceId 기물 ID
      * @return 기물 선택 여부
      */
     public boolean isAlreadySelected(@NonNull UUID pieceId) {
-        if (state instanceof SelectionState selectionState) {
-            return selectionState.isSelected(pieceId);
-        }
-
-        return false;
+        return (state instanceof SelectionState selection) && selection.isSelected(pieceId);
     }
 
     /**
-     * 참여자가 기물을 선택했는지 확인합니다.
+     * 플레이어의 기물 선택 완료 여부를 확인합니다.
      *
      * @param playerId 플레이어 ID
-     * @return 기물 선택 완료 여부
+     * @return 선택 완료 여부
      */
     public boolean hasSelectedPiece(@NonNull UUID playerId) {
-        if (state instanceof SelectionState selectionState) {
-            return selectionState.hasSelectionFor(playerId);
-        }
-
-        return false;
+        return (state instanceof SelectionState selection) && selection.hasSelectionFor(playerId);
     }
 
     /**
-     * 체스판에 배치된 모든 일반 기물 목록을 산출합니다.
+     * 일반 기물 목록을 산출합니다.
      *
      * @return 일반 기물 목록
      */
@@ -187,7 +208,7 @@ public record Game(
     }
 
     /**
-     * 좌표 기반의 일반 기물 배치 현황을 산출합니다.
+     * 일반 기물 배치 현황을 산출합니다.
      *
      * @return 기물 배치 현황
      */
@@ -199,5 +220,10 @@ public record Game(
                         Map.Entry::getKey,
                         entry -> (UnitPiece) entry.getValue())
                 );
+    }
+
+    @NonNull
+    private Game atState(@NonNull PhaseState nextState) {
+        return new Game(board, pieces, nextState);
     }
 }

--- a/src/main/java/dev/tecte/chessWar/game/domain/model/Game.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/model/Game.java
@@ -12,6 +12,7 @@ import dev.tecte.chessWar.piece.domain.model.UnitPiece;
 import lombok.NonNull;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -93,15 +94,15 @@ public record Game(
     }
 
     /**
-     * 플레이어의 기물 선택을 반영합니다.
+     * 참가자의 기물 선택을 반영합니다.
      *
-     * @param playerId 플레이어 ID
-     * @param pieceId  기물 ID
+     * @param participantId 참가자 ID
+     * @param pieceId       기물 ID
      * @return 업데이트된 게임
      * @throws GameException 단계 불일치, 기물 미발견, 선택 불가 또는 이미 선택된 경우
      */
     @NonNull
-    public Game selectPiece(@NonNull UUID playerId, @NonNull UUID pieceId) {
+    public Game selectPiece(@NonNull UUID participantId, @NonNull UUID pieceId) {
         if (!(state instanceof SelectionState selection)) {
             throw GameException.phaseMismatch(GamePhase.PIECE_SELECTION, phase());
         }
@@ -116,7 +117,7 @@ public record Game(
             throw GameException.pieceAlreadySelected();
         }
 
-        return atState(selection.select(playerId, pieceId));
+        return atState(selection.select(participantId, pieceId));
     }
 
     /**
@@ -157,6 +158,7 @@ public record Game(
      *
      * @return 기물 선택 단계 여부
      */
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean isInSelectionPhase() {
         return state instanceof SelectionState;
     }
@@ -185,13 +187,23 @@ public record Game(
     }
 
     /**
-     * 플레이어의 기물 선택 완료 여부를 확인합니다.
+     * 참가자의 기물 선택 완료 여부를 확인합니다.
      *
-     * @param playerId 플레이어 ID
+     * @param participantId 참가자 ID
      * @return 선택 완료 여부
      */
-    public boolean hasSelectedPiece(@NonNull UUID playerId) {
-        return (state instanceof SelectionState selection) && selection.hasSelectionFor(playerId);
+    public boolean hasSelectedPiece(@NonNull UUID participantId) {
+        return (state instanceof SelectionState selection) && selection.hasSelectionFor(participantId);
+    }
+
+    /**
+     * 모든 참가자의 기물 선택 완료 여부를 확인합니다.
+     *
+     * @param participantIds 참가자 ID 목록
+     * @return 모든 참여자 선택 완료 여부
+     */
+    public boolean hasSelectedPiece(@NonNull Collection<UUID> participantIds) {
+        return (state instanceof SelectionState selection) && selection.hasSelectionFor(participantIds);
     }
 
     /**

--- a/src/main/java/dev/tecte/chessWar/game/domain/model/PhaseTimerSettings.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/model/PhaseTimerSettings.java
@@ -1,0 +1,35 @@
+package dev.tecte.chessWar.game.domain.model;
+
+import lombok.NonNull;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * 특정 게임 단계에서 사용할 타이머의 구성을 정의합니다.
+ *
+ * @param duration 지속 시간
+ * @param visuals  시각적 연출 구성
+ */
+public record PhaseTimerSettings(Duration duration, TimerVisuals visuals) {
+    public PhaseTimerSettings {
+        Objects.requireNonNull(duration, "Duration cannot be null");
+        Objects.requireNonNull(visuals, "Visuals cannot be null");
+
+        if (duration.isNegative()) {
+            throw new IllegalArgumentException("Duration cannot be negative");
+        }
+    }
+
+    /**
+     * 타이머 설정을 생성합니다.
+     *
+     * @param duration 지속 시간
+     * @param visuals  시각적 연출 구성
+     * @return 타이머 설정
+     */
+    @NonNull
+    public static PhaseTimerSettings of(@NonNull Duration duration, @NonNull TimerVisuals visuals) {
+        return new PhaseTimerSettings(duration, visuals);
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/game/domain/model/PhaseTimerSettings.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/model/PhaseTimerSettings.java
@@ -9,38 +9,53 @@ import java.util.Objects;
 /**
  * 게임 단계별 타이머 설정입니다.
  *
- * @param duration 제한 시간
- * @param visuals  시각 효과 설정
+ * @param initialDuration 초기 제한 시간
+ * @param reducedDuration 단축 시 적용될 제한 시간
+ * @param visuals         시각 효과 설정
  */
-public record PhaseTimerSettings(Duration duration, TimerVisuals visuals) {
+public record PhaseTimerSettings(
+        Duration initialDuration,
+        Duration reducedDuration,
+        TimerVisuals visuals
+) {
     public PhaseTimerSettings {
-        Objects.requireNonNull(duration, "Duration cannot be null");
+        Objects.requireNonNull(initialDuration, "Initial duration cannot be null");
+        Objects.requireNonNull(reducedDuration, "Reduced duration cannot be null");
         Objects.requireNonNull(visuals, "Visuals cannot be null");
 
-        if (duration.isNegative()) {
-            throw new IllegalArgumentException("Duration cannot be negative");
+        if (initialDuration.isNegative()) {
+            throw new IllegalArgumentException("Initial duration cannot be negative");
+        }
+
+        if (reducedDuration.isNegative()) {
+            throw new IllegalArgumentException("Reduced duration cannot be negative");
         }
     }
 
     /**
      * 타이머 설정을 생성합니다.
      *
-     * @param duration 제한 시간
-     * @param visuals  시각 효과 설정
+     * @param initialDuration 초기 제한 시간
+     * @param reducedDuration 단축 시 적용될 제한 시간
+     * @param visuals         시각 효과 설정
      * @return 타이머 설정
      */
     @NonNull
-    public static PhaseTimerSettings of(@NonNull Duration duration, @NonNull TimerVisuals visuals) {
-        return new PhaseTimerSettings(duration, visuals);
+    public static PhaseTimerSettings of(
+            @NonNull Duration initialDuration,
+            @NonNull Duration reducedDuration,
+            @NonNull TimerVisuals visuals
+    ) {
+        return new PhaseTimerSettings(initialDuration, reducedDuration, visuals);
     }
 
     /**
-     * 제한 시간을 초 단위로 제공합니다.
+     * 초기 제한 시간을 초 단위로 제공합니다.
      *
-     * @return 제한 시간
+     * @return 초기 제한 시간
      */
-    public long totalSeconds() {
-        return duration.toSeconds();
+    public long initialSeconds() {
+        return initialDuration.toSeconds();
     }
 
     /**

--- a/src/main/java/dev/tecte/chessWar/game/domain/model/PhaseTimerSettings.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/model/PhaseTimerSettings.java
@@ -1,15 +1,16 @@
 package dev.tecte.chessWar.game.domain.model;
 
 import lombok.NonNull;
+import net.kyori.adventure.text.Component;
 
 import java.time.Duration;
 import java.util.Objects;
 
 /**
- * 특정 게임 단계에서 사용할 타이머의 구성을 정의합니다.
+ * 게임 단계별 타이머 설정입니다.
  *
- * @param duration 지속 시간
- * @param visuals  시각적 연출 구성
+ * @param duration 제한 시간
+ * @param visuals  시각 효과 설정
  */
 public record PhaseTimerSettings(Duration duration, TimerVisuals visuals) {
     public PhaseTimerSettings {
@@ -24,12 +25,33 @@ public record PhaseTimerSettings(Duration duration, TimerVisuals visuals) {
     /**
      * 타이머 설정을 생성합니다.
      *
-     * @param duration 지속 시간
-     * @param visuals  시각적 연출 구성
+     * @param duration 제한 시간
+     * @param visuals  시각 효과 설정
      * @return 타이머 설정
      */
     @NonNull
     public static PhaseTimerSettings of(@NonNull Duration duration, @NonNull TimerVisuals visuals) {
         return new PhaseTimerSettings(duration, visuals);
+    }
+
+    /**
+     * 제한 시간을 초 단위로 제공합니다.
+     *
+     * @return 제한 시간
+     */
+    public long totalSeconds() {
+        return duration.toSeconds();
+    }
+
+    /**
+     * 타이머 제목을 렌더링합니다.
+     *
+     * @param phaseName     단계 이름
+     * @param remainingTime 남은 시간
+     * @return 제목
+     */
+    @NonNull
+    public Component renderTitle(@NonNull String phaseName, @NonNull Duration remainingTime) {
+        return visuals.renderTitle(phaseName, remainingTime);
     }
 }

--- a/src/main/java/dev/tecte/chessWar/game/domain/model/TimerSession.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/model/TimerSession.java
@@ -1,7 +1,5 @@
-package dev.tecte.chessWar.game.application;
+package dev.tecte.chessWar.game.domain.model;
 
-import dev.tecte.chessWar.game.domain.model.GamePhase;
-import dev.tecte.chessWar.game.domain.model.PhaseTimerSettings;
 import lombok.NonNull;
 import net.kyori.adventure.text.Component;
 
@@ -10,21 +8,25 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * 진행 중인 타이머 세션의 상태를 나타냅니다.
+ * 타이머 세션의 상태입니다.
  *
  * @param timerSettings    타이머 설정
  * @param phase            게임 단계
  * @param remainingSeconds 남은 초
  */
-record TimerSession(
+public record TimerSession(
         PhaseTimerSettings timerSettings,
         GamePhase phase,
         AtomicInteger remainingSeconds
 ) {
-    TimerSession {
+    public TimerSession {
         Objects.requireNonNull(timerSettings, "Settings cannot be null");
         Objects.requireNonNull(phase, "Phase cannot be null");
         Objects.requireNonNull(remainingSeconds, "Remaining seconds cannot be null");
+
+        if (remainingSeconds.get() < 0) {
+            throw new IllegalArgumentException("Remaining seconds cannot be negative");
+        }
     }
 
     /**
@@ -58,6 +60,25 @@ record TimerSession(
     }
 
     /**
+     * 타이머를 제한 시간으로 단축합니다.
+     * 현재 남은 시간이 목표 시간보다 큰 경우에만 단축됩니다.
+     *
+     * @param reducedSeconds 단축 시 적용될 남은 초
+     * @return 단축 성공 여부
+     */
+    public boolean accelerateTo(int reducedSeconds) {
+        int current = remainingSeconds.get();
+
+        if (current > reducedSeconds) {
+            remainingSeconds.set(reducedSeconds);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * 현재 남은 시간을 제공합니다.
      *
      * @return 남은 시간
@@ -68,12 +89,22 @@ record TimerSession(
     }
 
     /**
+     * 단축 시 적용될 제한 시간을 제공합니다.
+     *
+     * @return 단축 제한 시간
+     */
+    @NonNull
+    public Duration reducedDuration() {
+        return timerSettings.reducedDuration();
+    }
+
+    /**
      * 타이머 진행률을 산출합니다.
      *
      * @return 진행률
      */
     public double progress() {
-        return (double) remainingSeconds.get() / timerSettings.totalSeconds();
+        return (double) remainingSeconds.get() / timerSettings.initialSeconds();
     }
 
     /**

--- a/src/main/java/dev/tecte/chessWar/game/domain/model/TimerVisuals.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/model/TimerVisuals.java
@@ -1,0 +1,38 @@
+package dev.tecte.chessWar.game.domain.model;
+
+import lombok.NonNull;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+
+import java.time.Duration;
+
+/**
+ * 타이머의 시각적 연출 규칙을 정의합니다.
+ */
+public record TimerVisuals() {
+    /**
+     * 남은 시간을 렌더링합니다.
+     *
+     * @param phaseName 단계 이름
+     * @param remaining 남은 시간
+     * @return 렌더링된 제목
+     */
+    @NonNull
+    public Component renderTitle(@NonNull String phaseName, @NonNull Duration remaining) {
+        return Component.text()
+                .append(Component.text("[ ", NamedTextColor.AQUA))
+                .append(Component.text(phaseName, NamedTextColor.AQUA, TextDecoration.BOLD))
+                .append(Component.text(" ]", NamedTextColor.AQUA))
+                .append(Component.space())
+                .append(Component.text("시간이 ", NamedTextColor.WHITE))
+                .append(Component.text(format(remaining), NamedTextColor.GOLD))
+                .append(Component.text(" 남았습니다.", NamedTextColor.WHITE))
+                .build();
+    }
+
+    @NonNull
+    private String format(@NonNull Duration duration) {
+        return "%02d분 %02d초".formatted(duration.toMinutes(), duration.toSecondsPart());
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/game/domain/model/phase/PhaseState.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/model/phase/PhaseState.java
@@ -4,11 +4,11 @@ import dev.tecte.chessWar.game.domain.model.GamePhase;
 import lombok.NonNull;
 
 /**
- * 게임 단계별 상태 정보를 정의합니다.
+ * 게임의 각 단계별 진행 상태를 나타냅니다.
  */
 public sealed interface PhaseState permits
         SetupState,
-        SelectionState,
+        TimedState,
         TurnOrderState,
         BattleState,
         EndedState {

--- a/src/main/java/dev/tecte/chessWar/game/domain/model/phase/SelectionState.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/model/phase/SelectionState.java
@@ -1,8 +1,10 @@
 package dev.tecte.chessWar.game.domain.model.phase;
 
 import dev.tecte.chessWar.game.domain.model.GamePhase;
+import dev.tecte.chessWar.game.domain.model.PhaseTimerSettings;
 import lombok.NonNull;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -10,55 +12,77 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * 기물 선택 단계의 점유 현황을 관리합니다.
+ * 기물 선택 단계의 진행 상태입니다.
  *
- * @param selections 플레이어와 기물의 매핑 데이터
+ * @param selections    플레이어와 기물의 선택 현황
+ * @param timerSettings 타이머 설정
+ * @param remainingTime 남은 시간
  */
-public record SelectionState(Map<UUID, UUID> selections) implements PhaseState {
+public record SelectionState(
+        Map<UUID, UUID> selections,
+        PhaseTimerSettings timerSettings,
+        Duration remainingTime
+) implements TimedState {
     public SelectionState {
         Objects.requireNonNull(selections, "Selections map cannot be null");
+        Objects.requireNonNull(timerSettings, "Settings cannot be null");
+        Objects.requireNonNull(remainingTime, "Remaining time cannot be null");
+
         selections = Map.copyOf(selections);
     }
 
     /**
-     * 선택 정보를 기반으로 상태를 생성합니다.
+     * 기물 선택 상태를 생성합니다.
      *
-     * @param selections 플레이어-기물 매핑 데이터
-     * @return 선택 상태
+     * @param selections    선택 현황
+     * @param timerSettings 타이머 설정
+     * @param remainingTime 남은 시간
+     * @return 기물 선택 상태
      */
     @NonNull
-    public static SelectionState of(@NonNull Map<UUID, UUID> selections) {
-        return new SelectionState(selections);
+    public static SelectionState of(
+            @NonNull Map<UUID, UUID> selections,
+            @NonNull PhaseTimerSettings timerSettings,
+            @NonNull Duration remainingTime
+    ) {
+        return new SelectionState(selections, timerSettings, remainingTime);
     }
 
     /**
-     * 비어 있는 초기 상태를 생성합니다.
+     * 초기 기물 선택 상태를 생성합니다.
      *
-     * @return 초기 상태
+     * @param timerSettings 초기 타이머 설정
+     * @return 초기화된 선택 상태
      */
     @NonNull
-    public static SelectionState empty() {
-        return new SelectionState(Collections.emptyMap());
+    public static SelectionState initial(@NonNull PhaseTimerSettings timerSettings) {
+        return new SelectionState(Collections.emptyMap(), timerSettings, timerSettings.duration());
     }
 
     /**
-     * 기물 선택 정보가 추가된 새로운 상태를 제공합니다.
+     * 기물을 선택한 새로운 상태를 제공합니다.
      *
      * @param playerId 플레이어 ID
      * @param pieceId  선택된 기물 ID
      * @return 업데이트된 상태
      */
     @NonNull
-    public SelectionState withSelection(@NonNull UUID playerId, @NonNull UUID pieceId) {
+    public SelectionState select(@NonNull UUID playerId, @NonNull UUID pieceId) {
         Map<UUID, UUID> newSelections = new HashMap<>(selections);
 
         newSelections.put(playerId, pieceId);
 
-        return new SelectionState(newSelections);
+        return new SelectionState(newSelections, timerSettings, remainingTime);
+    }
+
+    @NonNull
+    @Override
+    public SelectionState remaining(@NonNull Duration remainingTime) {
+        return new SelectionState(selections, timerSettings, remainingTime);
     }
 
     /**
-     * 기물의 선택 여부를 확인합니다.
+     * 기물이 이미 선택되었는지 확인합니다.
      *
      * @param pieceId 기물 ID
      * @return 기물 선택 여부
@@ -68,7 +92,7 @@ public record SelectionState(Map<UUID, UUID> selections) implements PhaseState {
     }
 
     /**
-     * 플레이어의 선택 완료 여부를 확인합니다.
+     * 플레이어의 기물 선택 완료 여부를 확인합니다.
      *
      * @param playerId 플레이어 ID
      * @return 선택 완료 여부

--- a/src/main/java/dev/tecte/chessWar/game/domain/model/phase/SelectionState.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/model/phase/SelectionState.java
@@ -5,6 +5,7 @@ import dev.tecte.chessWar.game.domain.model.PhaseTimerSettings;
 import lombok.NonNull;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,7 +15,7 @@ import java.util.UUID;
 /**
  * 기물 선택 단계의 진행 상태입니다.
  *
- * @param selections    플레이어와 기물의 선택 현황
+ * @param selections    참가자와 기물의 선택 현황
  * @param timerSettings 타이머 설정
  * @param remainingTime 남은 시간
  */
@@ -56,21 +57,21 @@ public record SelectionState(
      */
     @NonNull
     public static SelectionState initial(@NonNull PhaseTimerSettings timerSettings) {
-        return new SelectionState(Collections.emptyMap(), timerSettings, timerSettings.duration());
+        return new SelectionState(Collections.emptyMap(), timerSettings, timerSettings.initialDuration());
     }
 
     /**
      * 기물을 선택한 새로운 상태를 제공합니다.
      *
-     * @param playerId 플레이어 ID
-     * @param pieceId  선택된 기물 ID
+     * @param participantId 참가자 ID
+     * @param pieceId       선택된 기물 ID
      * @return 업데이트된 상태
      */
     @NonNull
-    public SelectionState select(@NonNull UUID playerId, @NonNull UUID pieceId) {
+    public SelectionState select(@NonNull UUID participantId, @NonNull UUID pieceId) {
         Map<UUID, UUID> newSelections = new HashMap<>(selections);
 
-        newSelections.put(playerId, pieceId);
+        newSelections.put(participantId, pieceId);
 
         return new SelectionState(newSelections, timerSettings, remainingTime);
     }
@@ -92,13 +93,23 @@ public record SelectionState(
     }
 
     /**
-     * 플레이어의 기물 선택 완료 여부를 확인합니다.
+     * 참가자의 기물 선택 완료 여부를 확인합니다.
      *
-     * @param playerId 플레이어 ID
+     * @param participantId 참가자 ID
      * @return 선택 완료 여부
      */
-    public boolean hasSelectionFor(@NonNull UUID playerId) {
-        return selections.containsKey(playerId);
+    public boolean hasSelectionFor(@NonNull UUID participantId) {
+        return selections.containsKey(participantId);
+    }
+
+    /**
+     * 주어진 모든 참가자의 기물 선택 완료 여부를 확인합니다.
+     *
+     * @param participantIds 참가자 ID 목록
+     * @return 모두 선택 완료 여부
+     */
+    public boolean hasSelectionFor(@NonNull Collection<UUID> participantIds) {
+        return selections.keySet().containsAll(participantIds);
     }
 
     @NonNull

--- a/src/main/java/dev/tecte/chessWar/game/domain/model/phase/SetupState.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/model/phase/SetupState.java
@@ -4,16 +4,16 @@ import dev.tecte.chessWar.game.domain.model.GamePhase;
 import lombok.NonNull;
 
 /**
- * 준비 단계의 상태 표식입니다.
+ * 게임의 준비 단계 상태입니다.
  */
 public record SetupState() implements PhaseState {
     /**
-     * 표준 준비 상태를 생성합니다.
+     * 초기 준비 상태를 생성합니다.
      *
      * @return 준비 상태
      */
     @NonNull
-    public static SetupState empty() {
+    public static SetupState initial() {
         return new SetupState();
     }
 

--- a/src/main/java/dev/tecte/chessWar/game/domain/model/phase/TimedState.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/model/phase/TimedState.java
@@ -1,0 +1,36 @@
+package dev.tecte.chessWar.game.domain.model.phase;
+
+import dev.tecte.chessWar.game.domain.model.PhaseTimerSettings;
+import lombok.NonNull;
+
+import java.time.Duration;
+
+/**
+ * 타이머가 포함된 게임 단계 상태입니다.
+ */
+public sealed interface TimedState extends PhaseState permits SelectionState {
+    /**
+     * 현재 단계의 남은 시간을 제공합니다.
+     *
+     * @return 남은 시간
+     */
+    @NonNull
+    Duration remainingTime();
+
+    /**
+     * 현재 단계의 타이머 설정을 제공합니다.
+     *
+     * @return 타이머 설정
+     */
+    @NonNull
+    PhaseTimerSettings timerSettings();
+
+    /**
+     * 남은 시간이 업데이트된 새로운 상태를 제공합니다.
+     *
+     * @param remainingTime 업데이트할 남은 시간
+     * @return 업데이트된 상태
+     */
+    @NonNull
+    TimedState remaining(@NonNull Duration remainingTime);
+}

--- a/src/main/java/dev/tecte/chessWar/game/domain/policy/GamePhaseTimerPolicy.java
+++ b/src/main/java/dev/tecte/chessWar/game/domain/policy/GamePhaseTimerPolicy.java
@@ -1,0 +1,21 @@
+package dev.tecte.chessWar.game.domain.policy;
+
+import dev.tecte.chessWar.game.domain.model.GamePhase;
+import dev.tecte.chessWar.game.domain.model.PhaseTimerSettings;
+import lombok.NonNull;
+
+import java.util.Optional;
+
+/**
+ * 게임 단계별 타이머 규칙을 결정합니다.
+ */
+public interface GamePhaseTimerPolicy {
+    /**
+     * 특정 단계의 타이머 설정을 찾습니다.
+     *
+     * @param phase 게임 단계
+     * @return 타이머 설정
+     */
+    @NonNull
+    Optional<PhaseTimerSettings> findSettings(@NonNull GamePhase phase);
+}

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/bootstrap/GameModule.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/bootstrap/GameModule.java
@@ -6,19 +6,25 @@ import com.google.inject.multibindings.Multibinder;
 import dev.tecte.chessWar.common.persistence.PersistableState;
 import dev.tecte.chessWar.game.application.GameAnnouncer;
 import dev.tecte.chessWar.game.application.GameFlowCoordinator;
+import dev.tecte.chessWar.game.application.GameTimerService;
 import dev.tecte.chessWar.game.application.port.GameRepository;
 import dev.tecte.chessWar.game.application.port.GameTaskManager;
+import dev.tecte.chessWar.game.application.port.GameTimerDisplay;
+import dev.tecte.chessWar.game.domain.policy.GamePhaseTimerPolicy;
 import dev.tecte.chessWar.game.infrastructure.bukkit.BukkitGameTaskManager;
+import dev.tecte.chessWar.game.infrastructure.bukkit.BukkitGameTimerDisplay;
 import dev.tecte.chessWar.game.infrastructure.command.GameCommand;
 import dev.tecte.chessWar.game.infrastructure.listener.GameSelectionPhaseInitiator;
 import dev.tecte.chessWar.game.infrastructure.listener.GameSelectionStartAnnouncer;
 import dev.tecte.chessWar.game.infrastructure.listener.GameStartBattlefieldSetupInitiator;
 import dev.tecte.chessWar.game.infrastructure.listener.GameStopAnnounceListener;
 import dev.tecte.chessWar.game.infrastructure.listener.GameStopTaskCleanupListener;
-import dev.tecte.chessWar.game.infrastructure.listener.PlayerJoinInitiator;
+import dev.tecte.chessWar.game.infrastructure.listener.GameTimerInitiator;
 import dev.tecte.chessWar.game.infrastructure.listener.PieceInspectionInitiator;
 import dev.tecte.chessWar.game.infrastructure.listener.PieceSelectionAnnounceListener;
+import dev.tecte.chessWar.game.infrastructure.listener.PlayerJoinInitiator;
 import dev.tecte.chessWar.game.infrastructure.persistence.YmlGameRepository;
+import dev.tecte.chessWar.game.infrastructure.policy.DefaultGamePhaseTimerPolicy;
 import org.bukkit.event.Listener;
 
 /**
@@ -28,12 +34,16 @@ import org.bukkit.event.Listener;
 public class GameModule extends AbstractModule {
     @Override
     protected void configure() {
+        bind(GamePhaseTimerPolicy.class).to(DefaultGamePhaseTimerPolicy.class);
+
         bind(GameRepository.class).to(YmlGameRepository.class);
         bind(GameTaskManager.class).to(BukkitGameTaskManager.class);
+        bind(GameTimerDisplay.class).to(BukkitGameTimerDisplay.class);
+
         bind(GameFlowCoordinator.class).asEagerSingleton();
         bind(GameAnnouncer.class).asEagerSingleton();
+        bind(GameTimerService.class).asEagerSingleton();
 
-        Multibinder.newSetBinder(binder(), PersistableState.class).addBinding().to(YmlGameRepository.class);
         Multibinder.newSetBinder(binder(), BaseCommand.class).addBinding().to(GameCommand.class);
 
         Multibinder<Listener> listenerBinder = Multibinder.newSetBinder(binder(), Listener.class);
@@ -46,5 +56,8 @@ public class GameModule extends AbstractModule {
         listenerBinder.addBinding().to(PieceSelectionAnnounceListener.class);
         listenerBinder.addBinding().to(GameStopAnnounceListener.class);
         listenerBinder.addBinding().to(GameStopTaskCleanupListener.class);
+        listenerBinder.addBinding().to(GameTimerInitiator.class);
+
+        Multibinder.newSetBinder(binder(), PersistableState.class).addBinding().to(YmlGameRepository.class);
     }
 }

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/bootstrap/GameModule.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/bootstrap/GameModule.java
@@ -23,6 +23,8 @@ import dev.tecte.chessWar.game.infrastructure.listener.GameTimerInitiator;
 import dev.tecte.chessWar.game.infrastructure.listener.PieceInspectionInitiator;
 import dev.tecte.chessWar.game.infrastructure.listener.PieceSelectionAnnounceListener;
 import dev.tecte.chessWar.game.infrastructure.listener.PlayerJoinInitiator;
+import dev.tecte.chessWar.game.infrastructure.listener.SelectionCompletionAnnouncer;
+import dev.tecte.chessWar.game.infrastructure.listener.SelectionTimerAccelerator;
 import dev.tecte.chessWar.game.infrastructure.persistence.YmlGameRepository;
 import dev.tecte.chessWar.game.infrastructure.policy.DefaultGamePhaseTimerPolicy;
 import org.bukkit.event.Listener;
@@ -54,6 +56,8 @@ public class GameModule extends AbstractModule {
         listenerBinder.addBinding().to(PieceInspectionInitiator.class);
         listenerBinder.addBinding().to(GameSelectionStartAnnouncer.class);
         listenerBinder.addBinding().to(PieceSelectionAnnounceListener.class);
+        listenerBinder.addBinding().to(SelectionTimerAccelerator.class);
+        listenerBinder.addBinding().to(SelectionCompletionAnnouncer.class);
         listenerBinder.addBinding().to(GameStopAnnounceListener.class);
         listenerBinder.addBinding().to(GameStopTaskCleanupListener.class);
         listenerBinder.addBinding().to(GameTimerInitiator.class);

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/bukkit/BukkitGameTimerDisplay.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/bukkit/BukkitGameTimerDisplay.java
@@ -1,0 +1,42 @@
+package dev.tecte.chessWar.game.infrastructure.bukkit;
+
+import dev.tecte.chessWar.game.application.port.GameTimerDisplay;
+import dev.tecte.chessWar.infrastructure.bukkit.BukkitBossBarManager;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.text.Component;
+
+import java.util.Collection;
+import java.util.UUID;
+
+/**
+ * 보스바를 활용하여 게임 타이머의 표시를 관리합니다.
+ */
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class BukkitGameTimerDisplay implements GameTimerDisplay {
+    private final BukkitBossBarManager bossBarManager;
+
+    @Override
+    public void show(@NonNull Collection<UUID> targetIds, @NonNull Component title, double progress) {
+        bossBarManager.update(title, progress);
+        bossBarManager.show(targetIds);
+    }
+
+    @Override
+    public void show(@NonNull UUID playerId) {
+        bossBarManager.show(playerId);
+    }
+
+    @Override
+    public void update(@NonNull Component title, double progress) {
+        bossBarManager.update(title, progress);
+    }
+
+    @Override
+    public void hide() {
+        bossBarManager.hide();
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/listener/GameSelectionStartAnnouncer.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/listener/GameSelectionStartAnnouncer.java
@@ -2,10 +2,8 @@ package dev.tecte.chessWar.game.infrastructure.listener;
 
 import dev.tecte.chessWar.common.event.ChessWarStartedEvent;
 import dev.tecte.chessWar.game.application.GameAnnouncer;
-import dev.tecte.chessWar.game.application.port.GameRepository;
 import dev.tecte.chessWar.game.domain.event.GameParticipantJoinedEvent;
 import dev.tecte.chessWar.game.domain.event.GameSelectionStartedEvent;
-import dev.tecte.chessWar.game.domain.model.Game;
 import dev.tecte.chessWar.port.UserResolver;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -21,53 +19,42 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * 기물 선택 단계의 시각적 안내를 책임집니다.
+ * 기물 선택 가이드를 담당합니다.
  */
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class GameSelectionStartAnnouncer implements Listener {
-    private final GameRepository gameRepository;
     private final GameAnnouncer gameAnnouncer;
     private final UserResolver userResolver;
 
     /**
-     * 기물 선택 단계의 가이드를 복구합니다.
+     * 기물 선택 가이드를 재개합니다.
      *
      * @param event 시스템 시작 이벤트
      */
     @EventHandler(priority = EventPriority.MONITOR)
     public void recoverGuidance(@NonNull ChessWarStartedEvent event) {
-        if (!isSelectionOngoing()) {
-            return;
-        }
-
-        gameAnnouncer.startSelectionGuidance();
+        gameAnnouncer.restoreSelectionGuidance();
     }
 
     /**
-     * 기물 선택 단계의 가이드를 복구합니다.
+     * 참가자에게 기물 선택 가이드를 즉시 새로고침합니다.
      *
-     * @param event 참여자 복귀 이벤트
+     * @param event 참가자 접속 이벤트
      */
     @EventHandler(priority = EventPriority.MONITOR)
     public void recoverGuidance(@NonNull GameParticipantJoinedEvent event) {
-        if (!isSelectionOngoing()) {
-            return;
-        }
-
         Optional<Player> foundPlayer = userResolver.findPlayer(event.playerId());
 
         if (foundPlayer.isEmpty()) {
             return;
         }
 
-        Player player = foundPlayer.get();
-
-        gameAnnouncer.refreshSelectionStatus(player);
+        gameAnnouncer.refreshSelectionStatus(foundPlayer.get());
     }
 
     /**
-     * 참여자에게 기물 선택 단계의 시작을 알리고 가이드를 안내합니다.
+     * 기물 선택 시작을 알리고 가이드를 시작합니다.
      *
      * @param event 기물 선택 시작 이벤트
      */
@@ -80,12 +67,5 @@ public class GameSelectionStartAnnouncer implements Listener {
 
         gameAnnouncer.announceSelectionStart(targets);
         gameAnnouncer.startSelectionGuidance();
-    }
-
-    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    private boolean isSelectionOngoing() {
-        return gameRepository.find()
-                .filter(Game::isInSelectionPhase)
-                .isPresent();
     }
 }

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/listener/GameTimerInitiator.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/listener/GameTimerInitiator.java
@@ -1,0 +1,30 @@
+package dev.tecte.chessWar.game.infrastructure.listener;
+
+import dev.tecte.chessWar.game.application.GameFlowCoordinator;
+import dev.tecte.chessWar.game.domain.event.GameSelectionStartedEvent;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+/**
+ * 타이머의 시작 시점을 관리합니다.
+ */
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class GameTimerInitiator implements Listener {
+    private final GameFlowCoordinator flowCoordinator;
+
+    /**
+     * 기물 선택 단계가 시작되면 타이머를 시작합니다.
+     *
+     * @param event 기물 선택 시작 이벤트
+     */
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void initiateSelectionTimer(@NonNull GameSelectionStartedEvent event) {
+        flowCoordinator.initiatePhaseTimer(event.game().phase(), event.participants().keySet());
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/listener/GameTimerInitiator.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/listener/GameTimerInitiator.java
@@ -1,6 +1,8 @@
 package dev.tecte.chessWar.game.infrastructure.listener;
 
 import dev.tecte.chessWar.game.application.GameFlowCoordinator;
+import dev.tecte.chessWar.game.application.GameTimerService;
+import dev.tecte.chessWar.game.domain.event.GameParticipantJoinedEvent;
 import dev.tecte.chessWar.game.domain.event.GameSelectionStartedEvent;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -11,12 +13,13 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 /**
- * 타이머의 시작 시점을 관리합니다.
+ * 게임 타이머의 생명주기에 따른 표출 시점을 관리합니다.
  */
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class GameTimerInitiator implements Listener {
     private final GameFlowCoordinator flowCoordinator;
+    private final GameTimerService timerService;
 
     /**
      * 기물 선택 단계가 시작되면 타이머를 시작합니다.
@@ -26,5 +29,15 @@ public class GameTimerInitiator implements Listener {
     @EventHandler(priority = EventPriority.NORMAL)
     public void initiateSelectionTimer(@NonNull GameSelectionStartedEvent event) {
         flowCoordinator.initiatePhaseTimer(event.game().phase(), event.participants().keySet());
+    }
+
+    /**
+     * 참여자가 다시 합류하면 타이머를 복구합니다.
+     *
+     * @param event 플레이어 합류 이벤트
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void restoreTimerForParticipant(@NonNull GameParticipantJoinedEvent event) {
+        timerService.restore(event.playerId());
     }
 }

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/listener/GameTimerInitiator.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/listener/GameTimerInitiator.java
@@ -1,5 +1,6 @@
 package dev.tecte.chessWar.game.infrastructure.listener;
 
+import dev.tecte.chessWar.common.event.ChessWarStartedEvent;
 import dev.tecte.chessWar.game.application.GameFlowCoordinator;
 import dev.tecte.chessWar.game.application.GameTimerService;
 import dev.tecte.chessWar.game.domain.event.GameParticipantJoinedEvent;
@@ -13,7 +14,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 /**
- * 게임 타이머의 생명주기에 따른 표출 시점을 관리합니다.
+ * 게임 이벤트에 따른 타이머 활성화 및 복구 시점을 관리합니다.
  */
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
@@ -22,17 +23,27 @@ public class GameTimerInitiator implements Listener {
     private final GameTimerService timerService;
 
     /**
-     * 기물 선택 단계가 시작되면 타이머를 시작합니다.
+     * 진행 중인 게임의 타이머를 복구합니다.
+     *
+     * @param event 서버 시작 이벤트
+     */
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void resumeTimersOnStart(@NonNull ChessWarStartedEvent event) {
+        flowCoordinator.resumeActiveGameTimer();
+    }
+
+    /**
+     * 기물 선택 단계의 타이머를 활성화합니다.
      *
      * @param event 기물 선택 시작 이벤트
      */
     @EventHandler(priority = EventPriority.NORMAL)
     public void initiateSelectionTimer(@NonNull GameSelectionStartedEvent event) {
-        flowCoordinator.initiatePhaseTimer(event.game().phase(), event.participants().keySet());
+        flowCoordinator.initiatePhaseTimer(event.game(), event.participants().keySet());
     }
 
     /**
-     * 참여자가 다시 합류하면 타이머를 복구합니다.
+     * 참여자의 타이머 표시를 복구합니다.
      *
      * @param event 플레이어 합류 이벤트
      */

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/listener/SelectionCompletionAnnouncer.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/listener/SelectionCompletionAnnouncer.java
@@ -1,0 +1,30 @@
+package dev.tecte.chessWar.game.infrastructure.listener;
+
+import dev.tecte.chessWar.game.application.GameAnnouncer;
+import dev.tecte.chessWar.game.domain.event.AllParticipantsSelectedEvent;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+/**
+ * 기물 선택 완료 시 알림을 담당합니다.
+ */
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class SelectionCompletionAnnouncer implements Listener {
+    private final GameAnnouncer gameAnnouncer;
+
+    /**
+     * 기물 선택 완료 시 이를 공지합니다.
+     *
+     * @param event 기물 선택 완료 이벤트
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onAllParticipantsSelected(@NonNull AllParticipantsSelectedEvent event) {
+        gameAnnouncer.announceSelectionCompletion();
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/listener/SelectionTimerAccelerator.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/listener/SelectionTimerAccelerator.java
@@ -1,0 +1,30 @@
+package dev.tecte.chessWar.game.infrastructure.listener;
+
+import dev.tecte.chessWar.game.application.GameFlowCoordinator;
+import dev.tecte.chessWar.game.domain.event.AllParticipantsSelectedEvent;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+/**
+ * 기물 선택 완료 시 타이머 단축을 담당합니다.
+ */
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class SelectionTimerAccelerator implements Listener {
+    private final GameFlowCoordinator flowCoordinator;
+
+    /**
+     * 기물 선택 완료 시 타이머를 단축합니다.
+     *
+     * @param event 기물 선택 완료 이벤트
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onAllParticipantsSelected(@NonNull AllParticipantsSelectedEvent event) {
+        flowCoordinator.accelerateSelectionTimer();
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/persistence/GameMapper.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/persistence/GameMapper.java
@@ -4,12 +4,15 @@ import dev.tecte.chessWar.board.domain.model.Board;
 import dev.tecte.chessWar.board.domain.model.Coordinate;
 import dev.tecte.chessWar.game.domain.model.Game;
 import dev.tecte.chessWar.game.domain.model.GamePhase;
+import dev.tecte.chessWar.game.domain.model.PhaseTimerSettings;
 import dev.tecte.chessWar.game.domain.model.phase.BattleState;
 import dev.tecte.chessWar.game.domain.model.phase.EndedState;
 import dev.tecte.chessWar.game.domain.model.phase.PhaseState;
 import dev.tecte.chessWar.game.domain.model.phase.SelectionState;
 import dev.tecte.chessWar.game.domain.model.phase.SetupState;
+import dev.tecte.chessWar.game.domain.model.phase.TimedState;
 import dev.tecte.chessWar.game.domain.model.phase.TurnOrderState;
+import dev.tecte.chessWar.game.domain.policy.GamePhaseTimerPolicy;
 import dev.tecte.chessWar.game.infrastructure.persistence.GamePersistenceConstants.Keys;
 import dev.tecte.chessWar.infrastructure.persistence.YmlParser;
 import dev.tecte.chessWar.infrastructure.persistence.exception.YmlMappingException;
@@ -21,48 +24,51 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.bukkit.configuration.ConfigurationSection;
 
+import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
- * 게임과 YAML 데이터 간 변환을 관리합니다.
+ * 게임과 YAML 데이터 간의 변환을 담당합니다.
  */
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class GameMapper {
-    // 기술적 중복 방지와 데이터 일관성 유지를 위해 타 도메인 매퍼를 유틸리티로 활용
+    private final GamePhaseTimerPolicy timerPolicy;
+    // 데이터 일관성 유지를 위해 타 도메인 매퍼를 유틸리티로 활용
     private final PieceMapper pieceMapper;
     private final YmlParser parser;
 
     /**
      * 게임을 데이터 맵으로 변환합니다.
      *
-     * @param game 변환할 게임
+     * @param game 게임
      * @return 데이터 맵
      */
     @NonNull
     public Map<String, Object> toMap(@NonNull Game game) {
-        Map<String, Object> stateMap = new HashMap<>();
+        Map<String, Object> map = new HashMap<>();
 
-        stateMap.put(Keys.PIECES, toMapPieces(game.pieces()));
-        stateMap.put(Keys.PHASE, toMapPhaseState(game.state()));
+        map.put(Keys.PIECES, toMapPieces(game.pieces()));
+        map.put(Keys.PHASE, toMapPhaseState(game.state()));
 
-        return Map.of(Keys.STATE, stateMap);
+        return map;
     }
 
     /**
      * 데이터 섹션으로부터 게임을 복원합니다.
      *
      * @param section 데이터 섹션
-     * @param board   게임이 진행될 체스판
-     * @return 복원된 게임
+     * @param board   체스판
+     * @return 게임
      */
     @NonNull
     public Game fromSection(@NonNull ConfigurationSection section, @NonNull Board board) {
-        ConfigurationSection stateSection = parser.requireSection(section, Keys.STATE);
-        Map<Coordinate, Piece> pieces = fromSectionPieces(parser.requireSection(stateSection, Keys.PIECES));
-        PhaseState state = fromSectionPhaseState(parser.requireSection(stateSection, Keys.PHASE));
+        Map<Coordinate, Piece> pieces = fromSectionPieces(parser.requireSection(section, Keys.PIECES));
+        PhaseState state = fromSectionPhaseState(parser.requireSection(section, Keys.PHASE));
 
         return Game.of(board, pieces, state);
     }
@@ -71,7 +77,8 @@ public class GameMapper {
     private Map<String, Object> toMapPieces(@NonNull Map<Coordinate, Piece> pieces) {
         Map<String, Object> map = new HashMap<>();
 
-        pieces.forEach((coordinate, piece) -> map.put(coordinate.toNotation(), pieceMapper.toMap(piece)));
+        pieces.forEach((coordinate, piece) ->
+                map.put(coordinate.toNotation(), pieceMapper.toMap(piece)));
 
         return map;
     }
@@ -82,10 +89,14 @@ public class GameMapper {
 
         map.put(Keys.CURRENT, state.phase().name());
 
+        if (state instanceof TimedState timedState) {
+            map.put(Keys.REMAINING_TIME, timedState.remainingTime().toString());
+        }
+
         switch (state) {
+            case SelectionState selection -> map.put(Keys.SELECTIONS, toMapSelections(selection));
             case SetupState ignored -> {
             }
-            case SelectionState s -> map.put(Keys.SELECTIONS, toMapSelections(s));
             case TurnOrderState ignored -> {
             }
             case BattleState ignored -> {
@@ -101,7 +112,8 @@ public class GameMapper {
     private Map<String, String> toMapSelections(@NonNull SelectionState state) {
         Map<String, String> map = new HashMap<>();
 
-        state.selections().forEach((playerId, pieceId) -> map.put(playerId.toString(), pieceId.toString()));
+        state.selections().forEach((playerId, pieceId) ->
+                map.put(playerId.toString(), pieceId.toString()));
 
         return map;
     }
@@ -116,7 +128,12 @@ public class GameMapper {
             try {
                 coordinate = Coordinate.from(key);
             } catch (IllegalArgumentException e) {
-                throw YmlMappingException.forInvalidFormat(key, section.getCurrentPath(), Coordinate.NOTATION_RANGE, e);
+                throw YmlMappingException.forInvalidFormat(
+                        key,
+                        section.getCurrentPath(),
+                        Coordinate.NOTATION_RANGE,
+                        e
+                );
             }
 
             Piece piece = pieceMapper.fromSection(parser.requireSection(section, key));
@@ -130,10 +147,17 @@ public class GameMapper {
     @NonNull
     private PhaseState fromSectionPhaseState(@NonNull ConfigurationSection section) {
         GamePhase phase = parser.requireEnum(section, Keys.CURRENT, GamePhase::from);
+        Optional<Duration> remainingTime = parser.findValue(section, Keys.REMAINING_TIME, String.class)
+                .map(Duration::parse);
 
         return switch (phase) {
-            case SETUP -> new SetupState();
-            case PIECE_SELECTION -> fromSectionSelectionState(section);
+            case SETUP -> SetupState.initial();
+            case PIECE_SELECTION -> {
+                PhaseTimerSettings timerSettings = requireTimerSettings(phase, section);
+                Duration time = remainingTime.orElse(timerSettings.duration());
+
+                yield fromSectionSelectionState(section, timerSettings, time);
+            }
             case TURN_ORDER_SELECTION -> new TurnOrderState();
             case BATTLE -> new BattleState();
             case ENDED -> new EndedState();
@@ -141,23 +165,39 @@ public class GameMapper {
     }
 
     @NonNull
-    private SelectionState fromSectionSelectionState(@NonNull ConfigurationSection section) {
-        return parser.findSection(section, Keys.SELECTIONS)
-                .map(this::createSelectionState)
-                .orElseGet(SelectionState::empty);
+    private PhaseTimerSettings requireTimerSettings(GamePhase phase, ConfigurationSection section) {
+        return timerPolicy.findSettings(phase)
+                .orElseThrow(() -> YmlMappingException.forMissingPhaseSetting(
+                        phase,
+                        PhaseTimerSettings.class,
+                        section.getCurrentPath()
+                ));
     }
 
     @NonNull
-    private SelectionState createSelectionState(@NonNull ConfigurationSection section) {
+    private SelectionState fromSectionSelectionState(
+            @NonNull ConfigurationSection section,
+            @NonNull PhaseTimerSettings timerSettings,
+            @NonNull Duration remainingTime
+    ) {
+        Map<UUID, UUID> selections = parser.findSection(section, Keys.SELECTIONS)
+                .map(this::parseSelectionMap)
+                .orElseGet(Collections::emptyMap);
+
+        return SelectionState.of(selections, timerSettings, remainingTime);
+    }
+
+    @NonNull
+    private Map<UUID, UUID> parseSelectionMap(@NonNull ConfigurationSection section) {
         Map<UUID, UUID> selections = new HashMap<>();
 
-        for (String key : section.getKeys(false)) {
+        section.getKeys(false).forEach(key -> {
             UUID playerId = parser.parseKeyAsUUID(section, key);
             UUID pieceId = parser.requireUUID(section, key);
 
             selections.put(playerId, pieceId);
-        }
+        });
 
-        return SelectionState.of(selections);
+        return selections;
     }
 }

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/persistence/GameMapper.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/persistence/GameMapper.java
@@ -154,7 +154,7 @@ public class GameMapper {
             case SETUP -> SetupState.initial();
             case PIECE_SELECTION -> {
                 PhaseTimerSettings timerSettings = requireTimerSettings(phase, section);
-                Duration time = remainingTime.orElse(timerSettings.duration());
+                Duration time = remainingTime.orElse(timerSettings.initialDuration());
 
                 yield fromSectionSelectionState(section, timerSettings, time);
             }

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/persistence/GamePersistenceConstants.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/persistence/GamePersistenceConstants.java
@@ -3,14 +3,14 @@ package dev.tecte.chessWar.game.infrastructure.persistence;
 import lombok.experimental.UtilityClass;
 
 /**
- * 게임 영속성 상수 집합입니다.
+ * 게임 도메인의 영속성 정의입니다.
  */
 @UtilityClass
 public class GamePersistenceConstants {
     public final String ROOT = "game";
 
     /**
-     * YAML 매핑 키 상수입니다.
+     * YAML 매핑 키입니다.
      */
     @UtilityClass
     public class Keys {
@@ -18,11 +18,12 @@ public class GamePersistenceConstants {
         public final String PIECES = "pieces";
         public final String PHASE = "phase";
         public final String CURRENT = "current";
+        public final String REMAINING_TIME = "remaining-time";
         public final String SELECTIONS = "selections";
     }
 
     /**
-     * 상태 경로 상수입니다.
+     * 상태 데이터 경로입니다.
      */
     @UtilityClass
     public class StatePaths {

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/persistence/YmlGameRepository.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/persistence/YmlGameRepository.java
@@ -1,6 +1,8 @@
 package dev.tecte.chessWar.game.infrastructure.persistence;
 
 import dev.tecte.chessWar.board.application.port.BoardRepository;
+import dev.tecte.chessWar.board.domain.model.Board;
+import dev.tecte.chessWar.game.application.GameTimerService;
 import dev.tecte.chessWar.game.application.port.GameRepository;
 import dev.tecte.chessWar.game.domain.model.Game;
 import dev.tecte.chessWar.game.infrastructure.persistence.GamePersistenceConstants.StatePaths;
@@ -17,16 +19,18 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 /**
- * YML 파일을 사용하여 게임의 영속성을 관리합니다.
+ * YAML 기반의 게임 영속성 저장소입니다.
  */
 @Singleton
 public class YmlGameRepository extends AbstractSingleYmlRepository<Game> implements GameRepository {
     private final BoardRepository boardRepository;
+    private final GameTimerService timerService;
     private final GameMapper mapper;
 
     @Inject
     public YmlGameRepository(
             @NonNull BoardRepository boardRepository,
+            @NonNull GameTimerService timerService,
             @NonNull GameMapper mapper,
             @NonNull ExceptionDispatcher dispatcher,
             @NonNull YmlFileManager fileManager,
@@ -34,6 +38,7 @@ public class YmlGameRepository extends AbstractSingleYmlRepository<Game> impleme
     ) {
         super(dispatcher, fileManager, persistenceExecutor);
         this.boardRepository = boardRepository;
+        this.timerService = timerService;
         this.mapper = mapper;
     }
 
@@ -47,13 +52,17 @@ public class YmlGameRepository extends AbstractSingleYmlRepository<Game> impleme
     protected Game deserialize(@NonNull ConfigurationSection section) {
         return boardRepository.find()
                 .map(board -> mapper.fromSection(section, board))
-                .orElseThrow(YmlMappingException::forMissingBoard);
+                .orElseThrow(() -> YmlMappingException.forMissingResource(Board.class));
     }
 
     @NonNull
     @Override
-    protected Map<String, Object> serialize(@NonNull Game entity) {
-        return mapper.toMap(entity);
+    protected Map<String, Object> serialize(@NonNull Game game) {
+        Game capturedGame = timerService.remainingTime()
+                .map(game::remaining)
+                .orElse(game);
+
+        return mapper.toMap(capturedGame);
     }
 
     @NonNull

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/persistence/YmlGameRepository.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/persistence/YmlGameRepository.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 /**
- * YAML 기반의 게임 영속성 저장소입니다.
+ * 게임 저장소의 YAML 구현체입니다.
  */
 @Singleton
 public class YmlGameRepository extends AbstractSingleYmlRepository<Game> implements GameRepository {
@@ -47,6 +47,11 @@ public class YmlGameRepository extends AbstractSingleYmlRepository<Game> impleme
         return find().isPresent();
     }
 
+    @Override
+    public void save(@NonNull Game game) {
+        super.save(captureRealTime(game));
+    }
+
     @NonNull
     @Override
     protected Game deserialize(@NonNull ConfigurationSection section) {
@@ -58,11 +63,14 @@ public class YmlGameRepository extends AbstractSingleYmlRepository<Game> impleme
     @NonNull
     @Override
     protected Map<String, Object> serialize(@NonNull Game game) {
-        Game capturedGame = timerService.remainingTime()
+        return mapper.toMap(captureRealTime(game));
+    }
+
+    // 실시간 남은 시간을 반영하여 데이터 정합성 확보
+    private Game captureRealTime(Game game) {
+        return timerService.remainingTime()
                 .map(game::remaining)
                 .orElse(game);
-
-        return mapper.toMap(capturedGame);
     }
 
     @NonNull

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/policy/DefaultGamePhaseTimerPolicy.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/policy/DefaultGamePhaseTimerPolicy.java
@@ -1,0 +1,29 @@
+package dev.tecte.chessWar.game.infrastructure.policy;
+
+import dev.tecte.chessWar.game.domain.model.GamePhase;
+import dev.tecte.chessWar.game.domain.model.PhaseTimerSettings;
+import dev.tecte.chessWar.game.domain.model.TimerVisuals;
+import dev.tecte.chessWar.game.domain.policy.GamePhaseTimerPolicy;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 게임 단계별 기본 타이머 규칙을 정의합니다.
+ */
+@Singleton
+public class DefaultGamePhaseTimerPolicy implements GamePhaseTimerPolicy {
+    private static final Map<GamePhase, PhaseTimerSettings> SETTINGS = Map.of(
+            GamePhase.PIECE_SELECTION, PhaseTimerSettings.of(Duration.ofMinutes(5), new TimerVisuals()),
+            GamePhase.TURN_ORDER_SELECTION, PhaseTimerSettings.of(Duration.ofMinutes(3), new TimerVisuals())
+    );
+
+    @NonNull
+    @Override
+    public Optional<PhaseTimerSettings> findSettings(@NonNull GamePhase phase) {
+        return Optional.ofNullable(SETTINGS.get(phase));
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/game/infrastructure/policy/DefaultGamePhaseTimerPolicy.java
+++ b/src/main/java/dev/tecte/chessWar/game/infrastructure/policy/DefaultGamePhaseTimerPolicy.java
@@ -17,8 +17,16 @@ import java.util.Optional;
 @Singleton
 public class DefaultGamePhaseTimerPolicy implements GamePhaseTimerPolicy {
     private static final Map<GamePhase, PhaseTimerSettings> SETTINGS = Map.of(
-            GamePhase.PIECE_SELECTION, PhaseTimerSettings.of(Duration.ofMinutes(5), new TimerVisuals()),
-            GamePhase.TURN_ORDER_SELECTION, PhaseTimerSettings.of(Duration.ofMinutes(3), new TimerVisuals())
+            GamePhase.PIECE_SELECTION, PhaseTimerSettings.of(
+                    Duration.ofMinutes(5),
+                    Duration.ofSeconds(10),
+                    new TimerVisuals()
+            ),
+            GamePhase.TURN_ORDER_SELECTION, PhaseTimerSettings.of(
+                    Duration.ofMinutes(3),
+                    Duration.ofSeconds(5),
+                    new TimerVisuals()
+            )
     );
 
     @NonNull

--- a/src/main/java/dev/tecte/chessWar/infrastructure/bootstrap/PluginModule.java
+++ b/src/main/java/dev/tecte/chessWar/infrastructure/bootstrap/PluginModule.java
@@ -7,6 +7,7 @@ import dev.tecte.chessWar.ChessWar;
 import dev.tecte.chessWar.board.infrastructure.bootstrap.BoardModule;
 import dev.tecte.chessWar.common.event.DomainEventDispatcher;
 import dev.tecte.chessWar.game.infrastructure.bootstrap.GameModule;
+import dev.tecte.chessWar.infrastructure.bukkit.BukkitBossBarManager;
 import dev.tecte.chessWar.infrastructure.bukkit.BukkitEntityResolver;
 import dev.tecte.chessWar.infrastructure.bukkit.BukkitEventDispatcher;
 import dev.tecte.chessWar.infrastructure.bukkit.BukkitTaskRunner;
@@ -42,12 +43,18 @@ public class PluginModule extends AbstractModule {
 
         bind(ChessWar.class).toInstance(plugin);
         bind(JavaPlugin.class).toInstance(plugin);
+        bind(Server.class).toInstance(server);
+
         bind(DomainEventDispatcher.class).to(BukkitEventDispatcher.class);
         bind(TaskRunner.class).to(BukkitTaskRunner.class);
+
         bind(UserNotifier.class).to(BukkitUserNotifier.class);
         bind(UserResolver.class).to(BukkitUserResolver.class);
         bind(WorldResolver.class).to(BukkitWorldResolver.class);
         bind(EntityResolver.class).to(BukkitEntityResolver.class);
+
+        bind(BukkitBossBarManager.class).asEagerSingleton();
+
         bind(ConsoleCommandSender.class).toInstance(Bukkit.getConsoleSender());
         bind(BukkitScheduler.class).toInstance(server.getScheduler());
         bind(PluginManager.class).toInstance(server.getPluginManager());

--- a/src/main/java/dev/tecte/chessWar/infrastructure/bukkit/BukkitBossBarManager.java
+++ b/src/main/java/dev/tecte/chessWar/infrastructure/bukkit/BukkitBossBarManager.java
@@ -1,0 +1,119 @@
+package dev.tecte.chessWar.infrastructure.bukkit;
+
+import dev.tecte.chessWar.port.UserResolver;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Bukkit 기반으로 보스바의 표시를 관리합니다.
+ */
+@Singleton
+public class BukkitBossBarManager {
+    private final UserResolver userResolver;
+    private final BossBar bossBar;
+
+    private final Set<UUID> viewers = ConcurrentHashMap.newKeySet();
+
+    @Inject
+    public BukkitBossBarManager(@NonNull UserResolver userResolver) {
+        this.userResolver = userResolver;
+        this.bossBar = BossBar.bossBar(
+                Component.empty(),
+                BossBar.MAX_PROGRESS,
+                BossBar.Color.WHITE,
+                BossBar.Overlay.PROGRESS
+        );
+    }
+
+    /**
+     * 보스바를 보여줍니다.
+     *
+     * @param playerIds 플레이어 ID 목록
+     */
+    public void show(@NonNull Collection<UUID> playerIds) {
+        playerIds.forEach(this::show);
+    }
+
+    /**
+     * 보스바를 보여줍니다.
+     *
+     * @param playerId 플레이어 ID
+     */
+    public void show(@NonNull UUID playerId) {
+        Optional<Player> player = userResolver.findPlayer(playerId);
+
+        if (player.isEmpty()) {
+            return;
+        }
+
+        show(player.get());
+    }
+
+    /**
+     * 보스바를 보여줍니다.
+     *
+     * @param player 플레이어
+     */
+    public void show(@NonNull Player player) {
+        viewers.add(player.getUniqueId());
+        player.showBossBar(bossBar);
+    }
+
+    /**
+     * 시각적 상태를 업데이트합니다.
+     *
+     * @param title    제목
+     * @param progress 진행률
+     */
+    public void update(@NonNull Component title, double progress) {
+        float clampedProgress = (float) Math.clamp(progress, BossBar.MIN_PROGRESS, BossBar.MAX_PROGRESS);
+
+        bossBar.name(title);
+        bossBar.progress(clampedProgress);
+        bossBar.color(determineColor(clampedProgress));
+    }
+
+    /**
+     * 보스바를 숨깁니다.
+     *
+     * @param playerId 플레이어 ID
+     */
+    public void hide(@NonNull UUID playerId) {
+        hideUI(playerId);
+        viewers.remove(playerId);
+    }
+
+    /**
+     * 보스바를 숨깁니다.
+     */
+    public void hide() {
+        viewers.forEach(this::hideUI);
+        viewers.clear();
+    }
+
+    private void hideUI(@NonNull UUID id) {
+        userResolver.findPlayer(id)
+                .ifPresent(player -> player.hideBossBar(bossBar));
+    }
+
+    @NonNull
+    private BossBar.Color determineColor(float progress) {
+        if (progress > 0.5f) {
+            return BossBar.Color.GREEN;
+        } else if (progress > 0.2f) {
+            return BossBar.Color.YELLOW;
+        } else {
+            return BossBar.Color.RED;
+        }
+    }
+}

--- a/src/main/java/dev/tecte/chessWar/infrastructure/persistence/exception/YmlMappingException.java
+++ b/src/main/java/dev/tecte/chessWar/infrastructure/persistence/exception/YmlMappingException.java
@@ -5,7 +5,7 @@ import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * YAML 데이터 매핑 관련 시스템 예외입니다.
+ * YAML 데이터 매핑 중에 발생하는 시스템 예외입니다.
  * <p>
  * 이 예외는 시스템 로그만 기록하며, 사용자에게는 별도의 알림을 보내지 않습니다.
  */
@@ -19,11 +19,11 @@ public class YmlMappingException extends SystemException {
     }
 
     /**
-     * 키 누락 예외를 생성합니다.
+     * 필수 키 누락 예외를 생성합니다.
      *
-     * @param key  누락된 키
+     * @param key  대상 키
      * @param path 섹션 경로
-     * @return 생성된 예외
+     * @return 매핑 예외
      */
     @NonNull
     public static YmlMappingException forMissingKey(@NonNull String key, @Nullable String path) {
@@ -31,13 +31,13 @@ public class YmlMappingException extends SystemException {
     }
 
     /**
-     * 타입 불일치 예외를 생성합니다.
+     * 값 타입 불일치 예외를 생성합니다.
      *
-     * @param key      키
+     * @param key      대상 키
      * @param path     섹션 경로
      * @param expected 기대 타입
      * @param actual   실제 타입
-     * @return 생성된 예외
+     * @return 매핑 예외
      */
     @NonNull
     public static YmlMappingException forInvalidType(
@@ -46,18 +46,17 @@ public class YmlMappingException extends SystemException {
             @NonNull String expected,
             @NonNull String actual
     ) {
-        return new YmlMappingException(
-                "Invalid value type [Key: %s, Path: %s, Expected: %s, Actual: %s]".formatted(key, path, expected, actual)
-        );
+        return new YmlMappingException("Invalid value type [Key: %s, Path: %s, Expected: %s, Actual: %s]"
+                .formatted(key, path, expected, actual));
     }
 
     /**
      * Enum 상수 불일치 예외를 생성합니다.
      *
-     * @param key   키
+     * @param key   대상 키
      * @param path  섹션 경로
-     * @param value 잘못된 값
-     * @return 생성된 예외
+     * @param value 대상 값
+     * @return 매핑 예외
      */
     @NonNull
     public static YmlMappingException forInvalidEnumValue(
@@ -65,17 +64,18 @@ public class YmlMappingException extends SystemException {
             @Nullable String path,
             @NonNull String value
     ) {
-        return new YmlMappingException("Invalid enum value [Key: %s, Path: %s, Value: %s]".formatted(key, path, value));
+        return new YmlMappingException("Invalid enum value [Key: %s, Path: %s, Value: %s]"
+                .formatted(key, path, value));
     }
 
     /**
-     * 형식 불일치 예외를 생성합니다.
+     * 데이터 형식 불일치 예외를 생성합니다.
      *
-     * @param value          잘못된 값
+     * @param value          대상 값
      * @param path           섹션 경로
      * @param expectedFormat 기대 형식
-     * @param cause          원인 예외
-     * @return 생성된 예외
+     * @param cause          발생 원인
+     * @return 매핑 예외
      */
     @NonNull
     public static YmlMappingException forInvalidFormat(
@@ -85,18 +85,39 @@ public class YmlMappingException extends SystemException {
             @Nullable Throwable cause
     ) {
         return new YmlMappingException(
-                "Invalid value format [Value: %s, Section: %s, Expected: %s]".formatted(value, path, expectedFormat),
+                "Invalid value format [Value: %s, Section: %s, Expected: %s]"
+                        .formatted(value, path, expectedFormat),
                 cause
         );
     }
 
     /**
-     * 필수 체스판 데이터 누락 예외를 생성합니다.
+     * 게임 단계의 설정 데이터 누락 예외를 생성합니다.
      *
-     * @return 생성된 예외
+     * @param phase       게임 단계
+     * @param settingType 설정 타입
+     * @param path        섹션 경로
+     * @return 매핑 예외
      */
     @NonNull
-    public static YmlMappingException forMissingBoard() {
-        return new YmlMappingException("Required resource is missing [Resource: Board, Context: Game Creation]");
+    public static YmlMappingException forMissingPhaseSetting(
+            @NonNull Object phase,
+            @NonNull Class<?> settingType,
+            @Nullable String path
+    ) {
+        return new YmlMappingException("Missing %s for phase [Phase: %s, Section: %s]"
+                .formatted(settingType.getSimpleName(), phase, path));
+    }
+
+    /**
+     * 필수 리소스 누락 예외를 생성합니다.
+     *
+     * @param resourceType 리소스 타입
+     * @return 매핑 예외
+     */
+    @NonNull
+    public static YmlMappingException forMissingResource(@NonNull Class<?> resourceType) {
+        return new YmlMappingException("Required resource is missing [Resource: %s]"
+                .formatted(resourceType.getSimpleName()));
     }
 }


### PR DESCRIPTION
## 📝 Description
게임의 각 단계에 따른 제한 시간을 관리하고 플레이어에게 시각적으로 전달하는 **BossBar 기반 타이머 시스템**을 구축했습니다. 단순히 시간을 표시하는 것에 그치지 않고, 서버 재시작이나 플레이어 재접속 시에도 타이머 상태가 유지되도록 **영속성 레이어(Yml)와 복구 메커니즘**을 구현했습니다. 또한, 기물 선택 단계에서 모든 참가자가 선택을 완료할 경우 대기 시간을 단축시키는 **타이머 단축 기능**을 구현했습니다.

## 🚀 Changes
### ⏳ 타이머 코어 시스템
* **BossBar 타이머 디스플레이**: `BukkitBossBarManager`와 `GameTimerDisplay`를 통해 단계별 남은 시간을 시각화하여 플레이어에게 실시간 피드백 제공
* **단계별 타이머 정책**: `GamePhaseTimerPolicy`를 도입하여 각 게임 단계마다 독립적인 시간 설정 및 로직을 적용할 수 있도록 유연성 확보
* **이벤트 기반 제어**: 타이머 만료 시 `GamePhaseExpiredEvent`를 발행하여 다음 단계로의 자동 전이를 도메인 이벤트로 처리

### 🛡️ 상태 관리 및 복구
* **상태 영속화**: `TimedState` 정보를 `GameMapper` 및 `YmlGameRepository`에 통합하여 서버 재시작 후에도 남은 시간 정보를 안전하게 복구
* **재접속 대응 로직**: `GameTimerInitiator`가 플레이어의 입장을 감지하여, 진행 중인 타이머의 BossBar를 즉시 다시 표시하도록 개선 (NPE 방어 로직 포함)
* **EDA 기반 자동 시작**: `ChessWarStartedEvent` 수신 시 활성화된 게임의 타이머 상태를 확인하고 자동으로 스케줄러를 재가동하는 복구 정책 구현

### ✨ UX 및 성능 최적화
* **기물 선택 가속화**: `SelectionTimerAccelerator`를 통해 모든 참가자가 기물 선택을 마쳤을 때 제한 시간을 즉시 단축시켜 불필요한 대기 시간 제거
* **타이머 데이터 캡슐화**: `TimerSession` 모델을 도입하여 타이머의 진행률 계산 및 단축 로직을 도메인 모델 내로 캡슐화
* **메시지 통합 관리**: `GameMessage`에 타이머 관련 텍스트 정보를 추가하여 비즈니스 로직과 UI 텍스트 분리

## ✅ Test Checklist
- [x] **BossBar 표시**: 각 단계 시작 시 상단에 타이머 BossBar가 정상적으로 나타나고 시간이 줄어드는지 확인
- [x] **재접속 복구**: 타이머가 진행 중일 때 나갔다 들어온 플레이어에게 BossBar가 즉시 다시 나타나는지 확인
- [x] **서버 재시작 복구**: 타이머 작동 중 서버 재시작 시, 저장된 남은 시간부터 타이머가 다시 시작되는지 확인
- [x] **타이머 단축**: 기물 선택 단계에서 마지막 참가자가 선택을 완료하면 BossBar 시간이 즉시 줄어드는지 확인

## 📸 Screenshots
| 게임 타이머 BossBar | 타이머 단축 |
| :---: | :---: |
| <img width="100%" alt="bossbar-timer-demo" src="https://github.com/user-attachments/assets/8cc4c823-e972-487e-b30b-1067e93f4b8a" /> | <img width="100%" alt="timer-acceleration" src="https://github.com/user-attachments/assets/6b44b79e-52fa-4a7b-8fdc-d3d4297638c9" /> |
| *단계별 남은 시간 시각화* | *조건 충족 시 타이머 게이지 급감 연출* |